### PR TITLE
깃헙 로그인 기능 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 	annotationProcessor 'org.projectlombok:lombok'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/aidea/aidea/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/aidea/aidea/domain/auth/controller/AuthController.java
@@ -1,15 +1,19 @@
 package com.aidea.aidea.domain.auth.controller;
 
-import com.aidea.aidea.domain.auth.dto.response.TokenResponse;
+import com.aidea.aidea.domain.auth.dto.response.UserResponse;
 import com.aidea.aidea.domain.auth.service.AuthService;
 import com.aidea.aidea.global.dto.ApiResponse;
+import com.aidea.aidea.global.exception.CustomException;
+import com.aidea.aidea.global.exception.ErrorCode;
+import com.aidea.aidea.global.util.CookieUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @Tag(name = "Auth")
 @RestController
@@ -18,14 +22,38 @@ import java.util.Map;
 public class AuthController {
 
     private final AuthService authService;
+    private final CookieUtils cookieUtils;
 
     @Operation(summary = "토큰 갱신")
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<TokenResponse>> refresh(
-            @RequestBody Map<String, String> request) {
+    public ResponseEntity<ApiResponse<Void>> refresh(HttpServletRequest request,
+                                                     HttpServletResponse response) {
+        String refreshToken = cookieUtils.extractCookieValue(request, "refresh_token")
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFRESH_TOKEN));
+        String newAccessToken = authService.refreshToken(refreshToken);
+        response.addCookie(cookieUtils.createAccessTokenCookie(newAccessToken));
+        return ResponseEntity.ok(ApiResponse.ok(null, "토큰이 갱신되었습니다."));
+    }
 
-        String refreshToken = request.get("refreshToken");
-        TokenResponse response = authService.refreshToken(refreshToken);
-        return ResponseEntity.ok(ApiResponse.ok(response));
+    @Operation(summary = "로그아웃")
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest request,
+                                                    HttpServletResponse response) {
+        String userId = (String) SecurityContextHolder.getContext()
+                .getAuthentication().getPrincipal();
+        authService.logout(Long.parseLong(userId));
+
+        response.addCookie(cookieUtils.expireCookie("access_token"));
+        response.addCookie(cookieUtils.expireCookie("refresh_token"));
+        return ResponseEntity.ok(ApiResponse.ok(null, "로그아웃 성공"));
+    }
+
+    @Operation(summary = "내 정보 조회")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponse>> me() {
+        String userId = (String) SecurityContextHolder.getContext()
+                .getAuthentication().getPrincipal();
+        UserResponse user = authService.getCurrentUser(Long.parseLong(userId));
+        return ResponseEntity.ok(ApiResponse.ok(user));
     }
 }

--- a/src/main/java/com/aidea/aidea/domain/auth/dto/response/UserResponse.java
+++ b/src/main/java/com/aidea/aidea/domain/auth/dto/response/UserResponse.java
@@ -1,0 +1,41 @@
+package com.aidea.aidea.domain.auth.dto.response;
+
+import com.aidea.aidea.domain.auth.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "사용자 정보 응답")
+public class UserResponse {
+
+    @Schema(description = "사용자 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "이메일", example = "user@example.com")
+    private String email;
+
+    @Schema(description = "이름", example = "홍길동")
+    private String name;
+
+    @Schema(description = "프로필 이미지 URL")
+    private String profileImageUrl;
+
+    @Schema(description = "OAuth 제공자", example = "github")
+    private String provider;
+
+    @Schema(description = "GitHub 사용자명", example = "kang-min-seok")
+    private String githubLogin;
+
+    public static UserResponse from(User user) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .profileImageUrl(user.getProfileImageUrl())
+                .provider(user.getProvider())
+                .githubLogin(user.getGithubLogin())
+                .build();
+    }
+}

--- a/src/main/java/com/aidea/aidea/domain/auth/entity/User.java
+++ b/src/main/java/com/aidea/aidea/domain/auth/entity/User.java
@@ -6,18 +6,19 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "users") // 테이블 이름 지정
+@Table(name = "users")
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED) // 빈 생성자 자동 생성(JPA)
-@AllArgsConstructor // 모든 필드를 받는 생성자 자동 생성
-@Builder // 객체 만들 때 사용 패턴
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class User {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY) //DB가 자동으로
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 255) //비어있으면 안 됨(필수), 같은 이메일 중복 안 됨, 최대 255글자
+    // GitHub 이메일 비공개 사용자 대응: nullable 허용
+    @Column(unique = true, length = 255)
     private String email;
 
     @Column(length = 100)
@@ -26,39 +27,49 @@ public class User {
     @Column(length = 500)
     private String profileImageUrl;
 
-    @Column(length = 50)
-    private String provider; //github - (어디서 로그인했는지 기록)
+    @Column(length = 50, nullable = false)
+    private String provider;
 
-    @Column(length = 255)
-    private String providerId; //github이 부여한 고유 ID
+    // GitHub 숫자 ID - 진정한 고유 식별자
+    @Column(nullable = false, unique = true, length = 255)
+    private String providerId;
+
+    // GitHub 사용자명 (kang-min-seok 형태) - API URL 구성에 사용
+    @Column(length = 100, nullable = false)
+    private String githubLogin;
+
+    // GitHub API 호출용 토큰
+    @Column(columnDefinition = "TEXT")
+    private String githubAccessToken;
 
     @Column(columnDefinition = "TEXT")
-    private String refreshToken; //JWT 갱신 토큰 (TEXT 타입)
+    private String refreshToken;
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
 
-    @PrePersist // DB에 처음 저장될 때 자동 실행(가입 시간 기록)
+    @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }
 
-    @PreUpdate //DB에 수정될 때 자동 실행(수정 시간 갱신)
+    @PreUpdate
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
 
-    //정보 바꾸는 방법(로그인할 때마다 최신 정보로 업데이트)
-    public void updateOAuthInfo(String name, String profileImageUrl) {
+    public void updateOAuthInfo(String name, String profileImageUrl,
+                                String githubLogin, String githubAccessToken) {
         this.name = name;
         this.profileImageUrl = profileImageUrl;
+        this.githubLogin = githubLogin;
+        this.githubAccessToken = githubAccessToken;
     }
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
-
 }

--- a/src/main/java/com/aidea/aidea/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/aidea/aidea/domain/auth/repository/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByProviderAndProviderId(String provider, String providerId);
 }

--- a/src/main/java/com/aidea/aidea/domain/auth/service/AuthService.java
+++ b/src/main/java/com/aidea/aidea/domain/auth/service/AuthService.java
@@ -1,6 +1,6 @@
 package com.aidea.aidea.domain.auth.service;
 
-import com.aidea.aidea.domain.auth.dto.response.TokenResponse;
+import com.aidea.aidea.domain.auth.dto.response.UserResponse;
 import com.aidea.aidea.domain.auth.entity.User;
 import com.aidea.aidea.domain.auth.repository.UserRepository;
 import com.aidea.aidea.global.exception.CustomException;
@@ -18,8 +18,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
-    public TokenResponse refreshToken(String refreshToken) {
-
+    public String refreshToken(String refreshToken) {
         if (!jwtTokenProvider.validateToken(refreshToken)) {
             throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
@@ -33,15 +32,20 @@ public class AuthService {
             throw new CustomException(ErrorCode.REFRESH_TOKEN_MISMATCH);
         }
 
-        String newAccessToken = jwtTokenProvider.createAccessToken(userId);
-        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+        return jwtTokenProvider.createAccessToken(userId);
+    }
 
-        user.updateRefreshToken(newRefreshToken);
-        userRepository.save(user);
+    @Transactional
+    public void logout(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        user.updateRefreshToken(null);
+    }
 
-        return TokenResponse.builder()
-                .accessToken(newAccessToken)
-                .refreshToken(newRefreshToken)
-                .build();
+    @Transactional(readOnly = true)
+    public UserResponse getCurrentUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return UserResponse.from(user);
     }
 }

--- a/src/main/java/com/aidea/aidea/global/config/SecurityConfig.java
+++ b/src/main/java/com/aidea/aidea/global/config/SecurityConfig.java
@@ -1,9 +1,13 @@
 package com.aidea.aidea.global.config;
 
+import com.aidea.aidea.global.security.CustomAuthenticationEntryPoint;
 import com.aidea.aidea.global.security.jwt.JwtAuthenticationFilter;
 import com.aidea.aidea.global.security.oauth2.CustomOAuth2UserService;
+import com.aidea.aidea.global.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
+import com.aidea.aidea.global.security.oauth2.OAuth2AuthenticationFailureHandler;
 import com.aidea.aidea.global.security.oauth2.OAuth2AuthenticationSuccessHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -26,6 +30,12 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler oAuth2SuccessHandler;
+    private final OAuth2AuthenticationFailureHandler oAuth2FailureHandler;
+    private final HttpCookieOAuth2AuthorizationRequestRepository cookieAuthorizationRequestRepository;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @Value("${frontend.url}")
+    private String frontendUrl;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -36,9 +46,11 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/auth/**",
                                 "/oauth2/**",
                                 "/login/oauth2/**",
+                                "/api/auth/refresh",
+                                "/favicon.ico",
+                                "/error",
                                 "/h2-console/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
@@ -47,11 +59,17 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                )
                 .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(endpoint ->
+                                endpoint.authorizationRequestRepository(cookieAuthorizationRequestRepository))
                         .userInfoEndpoint(userInfo ->
                                 userInfo.userService(customOAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailureHandler)
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
@@ -61,7 +79,11 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:5173"));
+        configuration.setAllowedOrigins(List.of(
+                "http://localhost:3000",
+                "http://localhost:5173",
+                frontendUrl
+        ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/aidea/aidea/global/dto/ApiResponse.java
+++ b/src/main/java/com/aidea/aidea/global/dto/ApiResponse.java
@@ -33,6 +33,15 @@ public class ApiResponse<T> {
                 .build();
     }
 
+    public static <T> ApiResponse<T> ok(T data, String message) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .code("SUCCESS")
+                .message(message)
+                .data(data)
+                .build();
+    }
+
     public static <T> ApiResponse<T> error(String code, String message) {
         return ApiResponse.<T>builder()
                 .success(false)

--- a/src/main/java/com/aidea/aidea/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aidea/aidea/global/exception/GlobalExceptionHandler.java
@@ -1,38 +1,32 @@
 package com.aidea.aidea.global.exception;
 
+import com.aidea.aidea.global.dto.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import com.aidea.aidea.global.dto.TestGlobalResponseDTO;
-
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // 1. 모든 RuntimeException 처리
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<TestGlobalResponseDTO<?>> handleRuntimeException(RuntimeException e) {
-
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
-                .badRequest()
-                .body(TestGlobalResponseDTO.error("RUNTIME_ERROR", e.getMessage()));
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.error(errorCode.getCode(), errorCode.getMessage()));
     }
 
-    // 2. IllegalArgumentException 처리 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<TestGlobalResponseDTO<?>> handleIllegalArgumentException(IllegalArgumentException e) {
-
+    public ResponseEntity<ApiResponse<?>> handleIllegalArgumentException(IllegalArgumentException e) {
         return ResponseEntity
                 .badRequest()
-                .body(TestGlobalResponseDTO.error("INVALID_ARGUMENT", e.getMessage()));
+                .body(ApiResponse.error("INVALID_ARGUMENT", e.getMessage()));
     }
 
-    // 3. 모든 예외
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<TestGlobalResponseDTO<?>> handleException(Exception e) {
-
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
         return ResponseEntity
-                .status(500)
-                .body(TestGlobalResponseDTO.error("INTERNAL_SERVER_ERROR", "서버 오류 발생"));
+                .internalServerError()
+                .body(ApiResponse.error("INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다."));
     }
 }

--- a/src/main/java/com/aidea/aidea/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/aidea/aidea/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.aidea.aidea.global.security;
+
+import com.aidea.aidea.global.dto.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        String uri = request.getRequestURI();
+        String requestedWith = request.getHeader("X-Requested-With");
+
+        if (uri.startsWith("/api/") || "XMLHttpRequest".equals(requestedWith)) {
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            objectMapper.writeValue(response.getWriter(),
+                    ApiResponse.error("UNAUTHORIZED", "인증이 필요합니다."));
+        } else {
+            // 비API 경로 (브라우저 직접 접근 등)는 OAuth2 시작점으로 리다이렉트
+            response.sendRedirect("/oauth2/authorization/github");
+        }
+    }
+}

--- a/src/main/java/com/aidea/aidea/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/aidea/aidea/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.aidea.aidea.global.security.jwt;
 
+import com.aidea.aidea.global.util.CookieUtils;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -7,55 +8,53 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.net.http.HttpResponse;
 import java.util.Collections;
 
 @Component
 @RequiredArgsConstructor
-//요청 1개 당 1번만 필터 실행
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CookieUtils cookieUtils;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        //토큰 꺼내기
         String token = resolveToken(request);
 
-        //토큰이 있고, 유효한지 확인
         if (token != null && jwtTokenProvider.validateToken(token)) {
-            //토큰에서 userId 꺼내기
-            Long  userId = jwtTokenProvider.getUserIdFromToken(token);
+            Long userId = jwtTokenProvider.getUserIdFromToken(token);
 
-            //Spring Security한테 "이 사람 인증됨" 알리기
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(
-                            userId.toString(),        //누구인지 (principal)
-                            null,                     // 비밀번호 (소셜 로그인 -> null)
-                            Collections.emptyList()   // 권한 목록 (지금은 비었음)
+                            userId.toString(),
+                            null,
+                            Collections.emptyList()
                     );
 
-            //여기에 인증된 유저 set하면 이후에 controller에서 꺼낼 수 있음
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
-        //다음 단계로 넘기기
         filterChain.doFilter(request, response);
     }
 
     private String resolveToken(HttpServletRequest request) {
+        // 1순위: access_token 쿠키
+        String cookieToken = cookieUtils.extractCookieValue(request, "access_token").orElse(null);
+        if (cookieToken != null) return cookieToken;
+
+        // 2순위: Authorization Bearer 헤더 (Swagger 테스트 등 개발 편의)
         String bearerToken = request.getHeader("Authorization");
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7); //7글자 뒤에 토큰만 잘라
+            return bearerToken.substring(7);
         }
-        return null; //토큰이 없으면 null 반환
+
+        return null;
     }
 }

--- a/src/main/java/com/aidea/aidea/global/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/aidea/aidea/global/security/oauth2/CustomOAuth2UserService.java
@@ -11,49 +11,50 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-//로그인 성공 후 뭐 할지
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
-    //DB에서 유저를 찾거나 저장해야 됨
     private final UserRepository userRepository;
 
     @Override
-    //GitHub이 정보 줄 때 자동 호출
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        //GitHub에서 사용자 정보 받기
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        //OAuth2UserInfo로 정보 정리
         OAuth2UserInfo userInfo = new OAuth2UserInfo(oAuth2User.getAttributes());
 
-        String name = userInfo.getName();
-        String email = userInfo.getEmail();
-        String profileImageUrl = userInfo.getProfileImageUrl();
         String provider = userRequest.getClientRegistration().getRegistrationId();
         String providerId = userInfo.getId();
+        String githubLogin = userInfo.getLogin();
+        String name = userInfo.getName();
+        String profileImageUrl = userInfo.getProfileImageUrl();
+        String githubAccessToken = userRequest.getAccessToken().getTokenValue();
 
-        //기존 회원인지 확인 -> 저장 or 업데이트
-        //이메일로 DB 조회
-        //→ 있으면: 이름/프로필 업데이트
-        //→ 없으면: 새 유저 생성 (자동 회원가입)
-        User user = userRepository.findByEmail(email)
+        // GitHub 이메일 비공개 사용자 대응: noreply 이메일 fallback
+        String email = userInfo.getEmail();
+        if (email == null) {
+            email = providerId + "+noreply@users.noreply.github.com";
+        }
+
+        final String finalEmail = email;
+
+        // providerId 기반으로 사용자 조회 (이메일보다 안정적인 고유 식별자)
+        userRepository.findByProviderAndProviderId(provider, providerId)
                 .map(existingUser -> {
-                    existingUser.updateOAuthInfo(name, profileImageUrl);
+                    existingUser.updateOAuthInfo(name, profileImageUrl, githubLogin, githubAccessToken);
                     return userRepository.save(existingUser);
                 })
                 .orElseGet(() -> {
                     User newUser = User.builder()
-                            .email(email)
+                            .email(finalEmail)
                             .name(name)
                             .profileImageUrl(profileImageUrl)
                             .provider(provider)
                             .providerId(providerId)
+                            .githubLogin(githubLogin)
+                            .githubAccessToken(githubAccessToken)
                             .build();
                     return userRepository.save(newUser);
                 });
 
         return oAuth2User;
-
     }
-
 }

--- a/src/main/java/com/aidea/aidea/global/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/aidea/aidea/global/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,97 @@
+package com.aidea.aidea.global.security.oauth2;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Base64;
+import java.util.Optional;
+
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository
+        implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private static final String COOKIE_NAME = "oauth2_auth_request";
+    private static final int COOKIE_EXPIRE_SECONDS = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return getCookieValue(request, COOKIE_NAME)
+                .map(this::deserialize)
+                .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+                                         HttpServletRequest request,
+                                         HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            deleteCookie(request, response, COOKIE_NAME);
+            return;
+        }
+        Cookie cookie = new Cookie(COOKIE_NAME, serialize(authorizationRequest));
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(COOKIE_EXPIRE_SECONDS);
+        response.addCookie(cookie);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+                                                                  HttpServletResponse response) {
+        OAuth2AuthorizationRequest request0 = loadAuthorizationRequest(request);
+        deleteCookie(request, response, COOKIE_NAME);
+        return request0;
+    }
+
+    private String serialize(OAuth2AuthorizationRequest authorizationRequest) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(authorizationRequest);
+            return Base64.getUrlEncoder().encodeToString(baos.toByteArray());
+        } catch (IOException e) {
+            throw new RuntimeException("OAuth2AuthorizationRequest 직렬화 실패", e);
+        }
+    }
+
+    private OAuth2AuthorizationRequest deserialize(String value) {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(Base64.getUrlDecoder().decode(value));
+             ObjectInputStream ois = new ObjectInputStream(bais)) {
+            return (OAuth2AuthorizationRequest) ois.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException("OAuth2AuthorizationRequest 역직렬화 실패", e);
+        }
+    }
+
+    private Optional<String> getCookieValue(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return Optional.empty();
+        for (Cookie cookie : cookies) {
+            if (name.equals(cookie.getName())) {
+                return Optional.of(cookie.getValue());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return;
+        for (Cookie cookie : cookies) {
+            if (name.equals(cookie.getName())) {
+                Cookie blank = new Cookie(name, "");
+                blank.setPath("/");
+                blank.setMaxAge(0);
+                response.addCookie(blank);
+            }
+        }
+    }
+}

--- a/src/main/java/com/aidea/aidea/global/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/aidea/aidea/global/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,26 @@
+package com.aidea.aidea.global.security.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Value("${frontend.url}")
+    private String frontendUrl;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        getRedirectStrategy().sendRedirect(request, response, frontendUrl + "/login?error=oauth2");
+    }
+}

--- a/src/main/java/com/aidea/aidea/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/aidea/aidea/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -5,44 +5,74 @@ import com.aidea.aidea.domain.auth.repository.UserRepository;
 import com.aidea.aidea.global.exception.CustomException;
 import com.aidea.aidea.global.exception.ErrorCode;
 import com.aidea.aidea.global.security.jwt.JwtTokenProvider;
+import com.aidea.aidea.global.util.CookieUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
+    private final CookieUtils cookieUtils;
+
+    @Value("${frontend.url}")
+    private String frontendUrl;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
                                         Authentication authentication) throws IOException {
+        try {
+            OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
+            OAuth2User oAuth2User = oauthToken.getPrincipal();
+            String provider = oauthToken.getAuthorizedClientRegistrationId();
 
-        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
-        String email = oAuth2User.getAttribute("email");
+            Object rawId = oAuth2User.getAttribute("id");
+            log.debug("[OAuth2Success] provider={}, rawId={}, rawIdType={}",
+                    provider, rawId, rawId != null ? rawId.getClass().getName() : "null");
 
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+            if (rawId == null) {
+                throw new IllegalStateException("GitHub OAuth2 응답에 id 속성이 없습니다.");
+            }
+            String providerId = String.valueOf(rawId);
 
-        String accessToken = jwtTokenProvider.createAccessToken(user.getId());
-        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+            User user = userRepository.findByProviderAndProviderId(provider, providerId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        user.updateRefreshToken(refreshToken);
-        userRepository.save(user);
+            Long userId = user.getId();
+            log.debug("[OAuth2Success] userId={}, provider={}, providerId={}", userId, provider, providerId);
 
-        String redirectUrl = "http://localhost:3000/oauth/callback"
-                + "?accessToken=" + accessToken
-                + "&refreshToken=" + refreshToken;
+            if (userId == null) {
+                throw new IllegalStateException("DB에서 조회한 User의 id가 null입니다. providerId=" + providerId);
+            }
 
-        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+            String accessToken = jwtTokenProvider.createAccessToken(userId);
+            String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+            user.updateRefreshToken(refreshToken);
+            userRepository.save(user);
+
+            response.addCookie(cookieUtils.createAccessTokenCookie(accessToken));
+            response.addCookie(cookieUtils.createRefreshTokenCookie(refreshToken));
+
+            getRedirectStrategy().sendRedirect(request, response, frontendUrl + "/");
+        } catch (Exception e) {
+            e.printStackTrace();
+            log.error("[OAuth2Success] 인증 성공 처리 중 예외 발생: {}", e.getMessage(), e);
+            getRedirectStrategy().sendRedirect(request, response, frontendUrl + "/login?error=server");
+        }
     }
 }

--- a/src/main/java/com/aidea/aidea/global/security/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/com/aidea/aidea/global/security/oauth2/OAuth2UserInfo.java
@@ -12,9 +12,15 @@ public class OAuth2UserInfo {
         this.attributes = attributes;
     }
 
-    //GitHub 고유 ID 꺼내기
+    //GitHub 고유 ID 꺼내기 (GitHub는 Integer로 반환하므로 String 변환)
     public String getId() {
-        return (String) attributes.get("id");
+        Object id = attributes.get("id");
+        return id != null ? String.valueOf(id) : null;
+    }
+
+    //GitHub 사용자명 꺼내기 (API URL 구성에 사용)
+    public String getLogin() {
+        return (String) attributes.get("login");
     }
 
     //이메일 꺼내기

--- a/src/main/java/com/aidea/aidea/global/util/CookieUtils.java
+++ b/src/main/java/com/aidea/aidea/global/util/CookieUtils.java
@@ -1,0 +1,51 @@
+package com.aidea.aidea.global.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+public class CookieUtils {
+
+    @Value("${app.cookie.secure}")
+    private boolean secure;
+
+    public Cookie createAccessTokenCookie(String token) {
+        Cookie cookie = new Cookie("access_token", token);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(secure);
+        cookie.setPath("/");
+        cookie.setMaxAge(1800);
+        return cookie;
+    }
+
+    public Cookie createRefreshTokenCookie(String token) {
+        Cookie cookie = new Cookie("refresh_token", token);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(secure);
+        cookie.setPath("/");
+        cookie.setMaxAge(1209600);
+        return cookie;
+    }
+
+    public Cookie expireCookie(String name) {
+        Cookie cookie = new Cookie(name, "");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(secure);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        return cookie;
+    }
+
+    public Optional<String> extractCookieValue(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return Optional.empty();
+        return Arrays.stream(request.getCookies())
+                .filter(c -> name.equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,22 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            redirect-uri: http://localhost:8080/login/oauth2/code/github
+
+frontend:
+  url: http://localhost:5173
+
+app:
+  cookie:
+    secure: false
+
+logging:
+  level:
+    com.aidea: DEBUG
+    org.springframework.security: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,22 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            redirect-uri: https://aidea-bu.duckdns.org/login/oauth2/code/github
+
+frontend:
+  url: ${FRONTEND_URL}
+
+app:
+  cookie:
+    secure: true
+
+logging:
+  level:
+    com.aidea: INFO
+    org.springframework.security: WARN

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,6 @@ spring:
     show-sql: ${SHOW_SQL:true}
     open-in-view: false
 
-  # --- OAuth2 클라이언트 설정 ---
   security:
     oauth2:
       client:
@@ -31,26 +30,21 @@ spring:
             client-secret: ${GITHUB_CLIENT_SECRET:secret}
             scope: read:user, user:email, repo, project
 
-# --- JWT 설정 ---
 jwt:
   secret: ${JWT_SECRET:jwtsecret}
-  access-token-expiry: 1800000      # 30분 (ms)
-  refresh-token-expiry: 1209600000  # 14일 (ms)
+  access-token-expiry: 1800000
+  refresh-token-expiry: 1209600000
 
-# --- 서버 설정 ---
 server:
   port: 8080
 
-# --- 프론트엔드 URL (OAuth 리다이렉트) ---
 frontend:
   url: ${FRONTEND_URL:http://localhost:5173}
 
-# --- 쿠키 설정 ---
 app:
   cookie:
     secure: ${COOKIE_SECURE:false}
 
-# --- Actuator ---
 management:
   endpoints:
     web:
@@ -60,7 +54,6 @@ management:
     health:
       show-details: never
 
-# --- Swagger ---
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
@@ -69,8 +62,7 @@ springdoc:
   api-docs:
     path: /v3/api-docs
 
-# --- 로깅 ---
 logging:
   level:
-    com.aidea.idea: DEBUG
+    com.aidea.aidea: DEBUG
     org.springframework.security: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: ${DDL_AUTO:update}
+      ddl-auto: ${DDL_AUTO:create}
     properties:
       hibernate:
         format_sql: true
@@ -27,13 +27,13 @@ spring:
       client:
         registration:
           github:
-            client-id: ${GITHUB_CLIENT_ID:your-github-client-id}
-            client-secret: ${GITHUB_CLIENT_SECRET:your-github-client-secret}
-            scope: read:user, user:email
+            client-id: ${GITHUB_CLIENT_ID:clientid}
+            client-secret: ${GITHUB_CLIENT_SECRET:secret}
+            scope: read:user, user:email, repo, project
 
 # --- JWT 설정 ---
 jwt:
-  secret: ${JWT_SECRET:my-super-secret-key-for-jwt-token-generation-must-be-256-bits-long!!}
+  secret: ${JWT_SECRET:jwtsecret}
   access-token-expiry: 1800000      # 30분 (ms)
   refresh-token-expiry: 1209600000  # 14일 (ms)
 
@@ -44,6 +44,11 @@ server:
 # --- 프론트엔드 URL (OAuth 리다이렉트) ---
 frontend:
   url: ${FRONTEND_URL:http://localhost:5173}
+
+# --- 쿠키 설정 ---
+app:
+  cookie:
+    secure: ${COOKIE_SECURE:false}
 
 # --- Actuator ---
 management:


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
> - Closes #55 


<br>

## 📝 작업 내용
### GitHub OAuth2 인증 쿠키 기반 전환 및 인증 인프라 정비

- JWT 전달 방식을 URL 파라미터 → HttpOnly 쿠키로 변경
- User 조회 기준을 이메일 → provider + providerId로 변경 (이메일 비공개 계정 대응)
- OAuth2 state를 HttpCookieOAuth2AuthorizationRequestRepository로 관리
- githubLogin, githubAccessToken 필드 User 엔티티에 추가
- 로그아웃, /me API 추가
- CustomAuthenticationEntryPoint, OAuth2FailureHandler 추가
- application-dev.yml / application-prod.yml 프로파일 분리


<br>

## 🖼️ 스크린샷 (선택)

<img width="1212" height="856" alt="스크린샷 2026-05-03 160140" src="https://github.com/user-attachments/assets/fd194640-3f79-426a-b4b5-6b0427615adf" />


<br>

## ⚠️ 실행 방법
### 1. 프로젝트 루트에 .env 파일 삽입

### 2. vscode 사용
<table>
  <tr>
    <td>
      <img width="872" alt="image" src="https://github.com/user-attachments/assets/69b9e77e-d481-4f38-ba52-b1d9b89220c5" />
    </td>
    <td>
      <img width="600" alt="image" src="https://github.com/user-attachments/assets/b1ad6208-9715-4d81-a146-5499b91f0666" />
    </td>
  </tr>
</table>

  - Extension Pack for Java, Spring Boot Tools 익스텐션 설치
  - `Cmd/Ctrl`+`Shift`+`P` → `Java: Reload Project`
  - vscode 사이드바의 Run and Debug 탭에서 F5 누르거나 실행버튼 클릭

### 3. intelij 사용
  - 프로젝트 루트에 .env 파일을 생성한 뒤 실행(Shift+F10)하면 끝입니다.
  - 별도 플러그인 설치나 Run Configuration 설정 불필요



<br>

## 🤔 주요 고민과 해결 과정
- 쿠키 기반 전환 이유: 
  - JWT를 URL에 담으면 브라우저 히스토리·로그에 토큰이 노출되어 보안 취약. HttpOnly 쿠키로 변경해 XSS 공격으로부터 토큰 보호
- 이메일 → providerId 전환 이유: 
  - GitHub 계정 중 이메일을 비공개로 설정한 경우 OAuth 응답에 이메일이 null로 오는 케이스가 있어, 항상 존재하는 provider + providerId 조합으로 사용자를 식별하도록 변경


