### PR TITLE
[Hotfix] 배포 환경 OAuth 문제 핫픽스

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2
 
 on:
   push:
-    branches: [ main, feat/51-cicd ]
+    branches: [ main, hotfix/* ]
   workflow_dispatch:
 
 jobs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     image: ${ECR_IMAGE}
     container_name: aidea-spring-blue
     environment:
+      SPRING_PROFILES_ACTIVE: prod
       DB_URL: jdbc:mysql://mysql:3306/aidea_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
@@ -48,6 +49,7 @@ services:
     image: ${ECR_IMAGE}
     container_name: aidea-spring-green
     environment:
+      SPRING_PROFILES_ACTIVE: prod
       DB_URL: jdbc:mysql://mysql:3306/aidea_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}

--- a/src/main/java/com/aidea/aidea/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/aidea/aidea/domain/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -31,7 +32,7 @@ public class AuthController {
         String refreshToken = cookieUtils.extractCookieValue(request, "refresh_token")
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFRESH_TOKEN));
         String newAccessToken = authService.refreshToken(refreshToken);
-        response.addCookie(cookieUtils.createAccessTokenCookie(newAccessToken));
+        response.addHeader(HttpHeaders.SET_COOKIE, cookieUtils.createAccessTokenCookie(newAccessToken).toString());
         return ResponseEntity.ok(GlobalResponse.ok("토큰이 갱신되었습니다."));
     }
 
@@ -43,8 +44,8 @@ public class AuthController {
                 .getAuthentication().getPrincipal();
         authService.logout(Long.parseLong(userId));
 
-        response.addCookie(cookieUtils.expireCookie("access_token"));
-        response.addCookie(cookieUtils.expireCookie("refresh_token"));
+        response.addHeader(HttpHeaders.SET_COOKIE, cookieUtils.expireCookie("access_token").toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, cookieUtils.expireCookie("refresh_token").toString());
         return ResponseEntity.ok(GlobalResponse.ok("로그아웃 성공"));
     }
 

--- a/src/main/java/com/aidea/aidea/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/aidea/aidea/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -63,8 +64,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             user.updateRefreshToken(refreshToken);
             userRepository.save(user);
 
-            response.addCookie(cookieUtils.createAccessTokenCookie(accessToken));
-            response.addCookie(cookieUtils.createRefreshTokenCookie(refreshToken));
+            response.addHeader(HttpHeaders.SET_COOKIE, cookieUtils.createAccessTokenCookie(accessToken).toString());
+            response.addHeader(HttpHeaders.SET_COOKIE, cookieUtils.createRefreshTokenCookie(refreshToken).toString());
 
             log.info("[AUTH] oauth2 login userId={} provider={}", userId, provider);
             getRedirectStrategy().sendRedirect(request, response, frontendUrl + "/");

--- a/src/main/java/com/aidea/aidea/global/util/CookieUtils.java
+++ b/src/main/java/com/aidea/aidea/global/util/CookieUtils.java
@@ -3,6 +3,7 @@ package com.aidea.aidea.global.util;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
@@ -14,31 +15,29 @@ public class CookieUtils {
     @Value("${app.cookie.secure}")
     private boolean secure;
 
-    public Cookie createAccessTokenCookie(String token) {
-        Cookie cookie = new Cookie("access_token", token);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(secure);
-        cookie.setPath("/");
-        cookie.setMaxAge(1800);
-        return cookie;
+    private ResponseCookie buildCookie(String name, String value, int maxAge) {
+        return ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(secure)
+                .path("/")
+                .maxAge(maxAge)
+                // 프론트(pages.dev)와 백엔드(duckdns.org)가 다른 도메인이므로
+                // cross-site 요청에서도 쿠키가 전송되도록 SameSite=None 설정.
+                // 개발 환경(secure=false)에서는 Lax 사용 (SameSite=None은 Secure 필수)
+                .sameSite(secure ? "None" : "Lax")
+                .build();
     }
 
-    public Cookie createRefreshTokenCookie(String token) {
-        Cookie cookie = new Cookie("refresh_token", token);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(secure);
-        cookie.setPath("/");
-        cookie.setMaxAge(1209600);
-        return cookie;
+    public ResponseCookie createAccessTokenCookie(String token) {
+        return buildCookie("access_token", token, 1800);
     }
 
-    public Cookie expireCookie(String name) {
-        Cookie cookie = new Cookie(name, "");
-        cookie.setHttpOnly(true);
-        cookie.setSecure(secure);
-        cookie.setPath("/");
-        cookie.setMaxAge(0);
-        return cookie;
+    public ResponseCookie createRefreshTokenCookie(String token) {
+        return buildCookie("refresh_token", token, 1209600);
+    }
+
+    public ResponseCookie expireCookie(String name) {
+        return buildCookie(name, "", 0);
     }
 
     public Optional<String> extractCookieValue(HttpServletRequest request, String name) {


### PR DESCRIPTION
## 📝 작업 내용
- docker-compose.yml에 `SPRING_PROFILES_ACTIVE=prod` 환경변수 추가
- 프로덕션 OAuth 로그인 후 `/api/auth/me` 401 응답 문제 수정
  - `Cookie` → `ResponseCookie`로 교체해 `SameSite=None; Secure` 적용

<br>

## 🤔 주요 고민과 해결 과정

- 프론트(`aidea-front.pages.dev`)와 백엔드(`aidea-bu.duckdns.org`)가 서로 다른 도메인이라 SameSite 속성 미설정 쿠키가 cross-site 요청 시 브라우저에서 전송되지 않았음. 
- 개발 환경은 둘 다 localhost라 동일 사이트로 인식되어 문제가 없었으나 프로덕션에서만 재현됨.
