### PR TITLE
문서 소켓 공통 에러 처리 시스템 구현

### DIFF
--- a/src/main/java/com/aidea/aidea/domain/documents/websocket/DocumentWebSocketHandler.java
+++ b/src/main/java/com/aidea/aidea/domain/documents/websocket/DocumentWebSocketHandler.java
@@ -2,6 +2,9 @@ package com.aidea.aidea.domain.documents.websocket;
 
 import com.aidea.aidea.domain.documents.service.DocumentService;
 import com.aidea.aidea.domain.teamspace.entity.MemberRole;
+import com.aidea.aidea.global.websocket.SocketErrorCode;
+import com.aidea.aidea.global.websocket.SocketErrorSender;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +35,7 @@ public class DocumentWebSocketHandler extends TextWebSocketHandler {
     private final DocumentUpdateBuffer updateBuffer;
     private final DocumentService documentService;
     private final ObjectMapper objectMapper;
+    private final SocketErrorSender socketErrorSender;
 
     // --- 연결 수립 ---
 
@@ -51,12 +55,39 @@ public class DocumentWebSocketHandler extends TextWebSocketHandler {
 
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
-        Map<String, Object> payload = objectMapper.readValue(message.getPayload(), new TypeReference<>() {});
-        String type = (String) payload.get("type");
-
-        switch (type) {
-            case "doc:update" -> handleDocUpdate(session, payload);
+        Map<String, Object> payload;
+        try {
+            payload = objectMapper.readValue(message.getPayload(), new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            log.warn("[WS] invalid JSON sessionId={}", session.getId());
+            socketErrorSender.send(session, SocketErrorCode.INVALID_MESSAGE);
+            return;
         }
+
+        String type = (String) payload.get("type");
+        if (type == null) {
+            socketErrorSender.send(session, SocketErrorCode.INVALID_MESSAGE);
+            return;
+        }
+
+        try {
+            switch (type) {
+                case "doc:update" -> handleDocUpdate(session, payload);
+                default -> {
+                    log.warn("[WS] unknown message type={} sessionId={}", type, session.getId());
+                    socketErrorSender.send(session, SocketErrorCode.INVALID_MESSAGE);
+                }
+            }
+        } catch (Exception e) {
+            log.error("[WS] unhandled error type={} sessionId={}", type, session.getId(), e);
+            socketErrorSender.send(session, SocketErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Override
+    public void handleTransportError(WebSocketSession session, Throwable exception) {
+        log.error("[WS] transport error sessionId={}", session.getId(), exception);
+        socketErrorSender.send(session, SocketErrorCode.INTERNAL_SERVER_ERROR);
     }
 
     // --- 연결 종료 ---
@@ -107,7 +138,21 @@ public class DocumentWebSocketHandler extends TextWebSocketHandler {
         String docId = (String) session.getAttributes().get("docId");
         String clientId = (String) session.getAttributes().get("userId");
         String base64Update = (String) payload.get("update");
-        byte[] updateBinary = Base64.getDecoder().decode(base64Update);
+
+        if (base64Update == null || base64Update.isBlank()) {
+            log.warn("[WS] doc:update missing update field sessionId={}", session.getId());
+            socketErrorSender.send(session, SocketErrorCode.INVALID_MESSAGE);
+            return;
+        }
+
+        byte[] updateBinary;
+        try {
+            updateBinary = Base64.getDecoder().decode(base64Update);
+        } catch (IllegalArgumentException e) {
+            log.warn("[WS] doc:update invalid base64 sessionId={}", session.getId());
+            socketErrorSender.send(session, SocketErrorCode.INVALID_MESSAGE);
+            return;
+        }
 
         log.debug("[WS] doc:update docId={} clientId={} bytes={}", docId, clientId, updateBinary.length);
 

--- a/src/main/java/com/aidea/aidea/global/websocket/SocketErrorCode.java
+++ b/src/main/java/com/aidea/aidea/global/websocket/SocketErrorCode.java
@@ -1,0 +1,24 @@
+package com.aidea.aidea.global.websocket;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SocketErrorCode {
+
+    // ===== 문서 실시간 편집 =====
+    INSUFFICIENT_PERMISSION("INSUFFICIENT_PERMISSION", "이 작업을 수행할 권한이 없습니다.", false),
+    DOCUMENT_NOT_FOUND("DOCUMENT_NOT_FOUND", "문서를 찾을 수 없습니다.", false),
+    INVALID_MESSAGE("INVALID_MESSAGE", "잘못된 요청입니다.", false),
+    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.", false),
+
+    // ===== 인증 (세션 종료 필요) =====
+    UNAUTHORIZED("UNAUTHORIZED", "인증이 만료되었습니다. 다시 로그인해 주세요.", true),
+    SESSION_EXPIRED("SESSION_EXPIRED", "세션이 만료되었습니다. 다시 로그인해 주세요.", true);
+
+    private final String code;
+    private final String message;
+    /** true이면 에러 전송 후 세션을 닫는다 */
+    private final boolean fatal;
+}

--- a/src/main/java/com/aidea/aidea/global/websocket/SocketErrorResponse.java
+++ b/src/main/java/com/aidea/aidea/global/websocket/SocketErrorResponse.java
@@ -1,0 +1,21 @@
+package com.aidea.aidea.global.websocket;
+
+import lombok.Getter;
+
+/** 소켓 에러 페이로드: {"event":"error","code":"...","message":"..."} */
+@Getter
+public class SocketErrorResponse {
+
+    private final String event = "error";
+    private final String code;
+    private final String message;
+
+    private SocketErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public static SocketErrorResponse of(SocketErrorCode errorCode) {
+        return new SocketErrorResponse(errorCode.getCode(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/aidea/aidea/global/websocket/SocketErrorSender.java
+++ b/src/main/java/com/aidea/aidea/global/websocket/SocketErrorSender.java
@@ -1,0 +1,39 @@
+package com.aidea.aidea.global.websocket;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+/**
+ * 모든 소켓 핸들러에서 공통으로 사용하는 에러 전송 유틸리티.
+ * fatal 에러(UNAUTHORIZED, SESSION_EXPIRED)는 에러 메시지 전송 후 세션을 닫는다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SocketErrorSender {
+
+    private final ObjectMapper objectMapper;
+
+    public void send(WebSocketSession session, SocketErrorCode errorCode) {
+        if (!session.isOpen()) {
+            return;
+        }
+        try {
+            String json = objectMapper.writeValueAsString(SocketErrorResponse.of(errorCode));
+            session.sendMessage(new TextMessage(json));
+
+            if (errorCode.isFatal()) {
+                session.close(CloseStatus.POLICY_VIOLATION);
+            }
+        } catch (IOException e) {
+            log.warn("[WS] failed to send error code={} sessionId={}", errorCode.getCode(), session.getId());
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- Closes #70


<br>

## 📝 작업 내용
- 문서 실시간 편집 에러 코드 enum 정의
- 모든 소켓 핸들러에서 공통으로 사용할 에러 전송 유틸리티 구현
- JSON 파싱 실패, 잘못된 Base64, 미지원 타입, 예외 등 실시간 편집 에러를 소켓으로 전달하도록 개선


<br>

## 🖼️ 스크린샷 (선택)

<img width="1258" height="862" alt="image" src="https://github.com/user-attachments/assets/78214c26-091b-4baf-b58b-c6df76b4f4a0" />



<br>

## 테스트 및 검증 내용
- 프론트에 연동하여 테스트

