### PR TITLE
feat: 문서별로 초안 생성

### DIFF
--- a/src/main/java/com/aidea/aidea/domain/aifeedback/controller/dto/ActiveFeedbackInfo.java
+++ b/src/main/java/com/aidea/aidea/domain/aifeedback/controller/dto/ActiveFeedbackInfo.java
@@ -1,0 +1,24 @@
+package com.aidea.aidea.domain.aifeedback.controller.dto;
+
+import com.aidea.aidea.domain.aifeedback.entity.Answer;
+import com.aidea.aidea.domain.aifeedback.entity.Feedback;
+import com.aidea.aidea.domain.aifeedback.entity.FeedbackStatus;
+import com.aidea.aidea.domain.aifeedback.entity.Question;
+
+import java.util.List;
+
+public record ActiveFeedbackInfo(
+        String feedbackId,
+        FeedbackStatus status,
+        String revisedMarkdown,
+        List<Question> questions
+) {
+    public static ActiveFeedbackInfo from(Feedback f) {
+        return new ActiveFeedbackInfo(
+                f.getId(),
+                f.getStatus(),
+                f.getRevisedMarkdown(),
+                f.getQuestions()
+        );
+    }
+}

--- a/src/main/java/com/aidea/aidea/domain/aifeedback/service/FeedbackService.java
+++ b/src/main/java/com/aidea/aidea/domain/aifeedback/service/FeedbackService.java
@@ -11,6 +11,7 @@ import com.aidea.aidea.domain.aifeedback.repository.FeedbackRepository;
 import com.aidea.aidea.domain.auth.entity.User;
 import com.aidea.aidea.domain.auth.repository.UserRepository;
 import com.aidea.aidea.domain.documents.entity.Document;
+import com.aidea.aidea.domain.documents.entity.DocumentAiStatus;
 import com.aidea.aidea.domain.documents.entity.DocumentUpdate;
 import com.aidea.aidea.domain.documents.repository.DocumentRepository;
 import com.aidea.aidea.domain.documents.repository.DocumentUpdateRepository;
@@ -60,6 +61,10 @@ public class FeedbackService {
                 .orElseThrow(() -> new CustomException(ErrorCode.DOCUMENT_NOT_FOUND));
 
         roleValidator.requireRole(document.getTeamspace().getTeamspaceId(), userId, MemberRole.OWNER, MemberRole.MEMBER);
+
+        if (document.getStatus() == DocumentAiStatus.DRAFT) {
+            throw new CustomException(ErrorCode.DRAFT_IN_PROGRESS);
+        }
 
         boolean inProgress = feedbackRepository.existsByDocumentIdAndStatusIn(docId, IN_PROGRESS_STATUSES);
         if (inProgress) {

--- a/src/main/java/com/aidea/aidea/domain/documents/dto/ActiveDraftInfo.java
+++ b/src/main/java/com/aidea/aidea/domain/documents/dto/ActiveDraftInfo.java
@@ -1,0 +1,9 @@
+package com.aidea.aidea.domain.documents.dto;
+
+import com.aidea.aidea.domain.draft.entity.DraftStatus;
+
+public record ActiveDraftInfo(
+        String draftId,
+        DraftStatus status,
+        String content
+) {}

--- a/src/main/java/com/aidea/aidea/domain/documents/entity/Document.java
+++ b/src/main/java/com/aidea/aidea/domain/documents/entity/Document.java
@@ -28,6 +28,9 @@ public class Document {
     @Column(nullable = false)
     private DocumentType type;
 
+    @Enumerated(EnumType.STRING)
+    private DocumentAiStatus status;
+
     @Column(nullable = false)
     private String title;
 

--- a/src/main/java/com/aidea/aidea/domain/documents/entity/DocumentAiStatus.java
+++ b/src/main/java/com/aidea/aidea/domain/documents/entity/DocumentAiStatus.java
@@ -1,0 +1,7 @@
+package com.aidea.aidea.domain.documents.entity;
+
+public enum DocumentAiStatus {
+    IDLE,                // 기본 상태
+    DRAFT,               // 초안 생성 중
+    FEEDBACK_IN_PROGRESS // 피드백 중
+}

--- a/src/main/java/com/aidea/aidea/domain/documents/websocket/DocumentWebSocketHandler.java
+++ b/src/main/java/com/aidea/aidea/domain/documents/websocket/DocumentWebSocketHandler.java
@@ -3,8 +3,10 @@ package com.aidea.aidea.domain.documents.websocket;
 import com.aidea.aidea.domain.aifeedback.entity.FeedbackStatus;
 import com.aidea.aidea.domain.aifeedback.repository.FeedbackRepository;
 import com.aidea.aidea.domain.aifeedback.service.FeedbackEventPublisher;
+import com.aidea.aidea.domain.documents.dto.ActiveDraftInfo;
 import com.aidea.aidea.domain.documents.dto.ActiveFeedbackInfo;
 import com.aidea.aidea.domain.documents.service.DocumentService;
+import com.aidea.aidea.domain.draft.repository.DraftRepository;
 import com.aidea.aidea.domain.teamspace.entity.MemberRole;
 import com.aidea.aidea.global.websocket.SocketErrorCode;
 import com.aidea.aidea.global.websocket.SocketErrorSender;
@@ -43,6 +45,7 @@ public class DocumentWebSocketHandler extends TextWebSocketHandler implements Fe
     private final DocumentUpdateBuffer updateBuffer;
     private final DocumentService documentService;
     private final FeedbackRepository feedbackRepository;
+    private final DraftRepository draftRepository;
     private final ObjectMapper objectMapper;
     private final SocketErrorSender socketErrorSender;
 
@@ -141,10 +144,15 @@ public class DocumentWebSocketHandler extends TextWebSocketHandler implements Fe
                 session.getId(), docId, snapshot != null, dbUpdates.size(),
                 activeFeedback != null ? activeFeedback.status() : "none");
 
+        ActiveDraftInfo activeDraft = draftRepository.findByDocumentId(docId)
+                .map(d -> new ActiveDraftInfo(d.getId(), d.getStatus(), d.getContent()))
+                .orElse(null);
+
         Map<String, Object> event = new LinkedHashMap<>();
         event.put("type", "doc:init");
         event.put("updates", updates);
         event.put("activeFeedback", activeFeedback);
+        event.put("activeDraft", activeDraft);
         session.sendMessage(new TextMessage(objectMapper.writeValueAsString(event)));
     }
 

--- a/src/main/java/com/aidea/aidea/domain/draft/entity/Draft.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/entity/Draft.java
@@ -1,0 +1,48 @@
+package com.aidea.aidea.domain.draft.entity;
+
+import com.aidea.aidea.domain.documents.entity.Document;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "drafts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Draft {
+
+    @Id
+    private String id;  //UUID
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "document_id", nullable = false)
+    private Document document;
+
+    @Setter
+    @Enumerated(EnumType.STRING)
+    private DraftStatus status;
+
+    @Setter
+    @Column(columnDefinition = "TEXT")
+    private String content; //Ai 생성 마크다운 (성공 시)
+
+    @Setter
+    @Column(name = "error_message")
+    private String errorMessage; //실패 시 사유
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    public static Draft create(String id, Document document) {
+        Draft draft = new Draft();
+        draft.id = id;
+        draft.document = document;
+        draft.status = DraftStatus.PENDING;
+        draft.createdAt = LocalDateTime.now();
+        return draft;
+    }
+}

--- a/src/main/java/com/aidea/aidea/domain/draft/entity/DraftStatus.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/entity/DraftStatus.java
@@ -1,0 +1,7 @@
+package com.aidea.aidea.domain.draft.entity;
+
+public enum DraftStatus {
+    PENDING,  // Gemini 호출 중
+    DONE,     // 초안 생성 완료
+    FAILED    // 실패
+}

--- a/src/main/java/com/aidea/aidea/domain/draft/repository/DraftRepository.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/repository/DraftRepository.java
@@ -1,0 +1,12 @@
+package com.aidea.aidea.domain.draft.repository;
+
+import com.aidea.aidea.domain.draft.entity.Draft;
+import com.aidea.aidea.domain.draft.entity.DraftStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DraftRepository extends JpaRepository<Draft, String> {
+    Optional<Draft> findByDocumentId(String documentId);
+    boolean existsByDocumentIdAndStatus(String documentId, DraftStatus status);
+}

--- a/src/main/java/com/aidea/aidea/domain/draft/service/DraftAsyncExecutor.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/service/DraftAsyncExecutor.java
@@ -1,0 +1,141 @@
+package com.aidea.aidea.domain.draft.service;
+
+import com.aidea.aidea.domain.aifeedback.service.FeedbackEventPublisher;
+import com.aidea.aidea.domain.documents.entity.Document;
+import com.aidea.aidea.domain.documents.entity.DocumentAiStatus;
+import com.aidea.aidea.domain.documents.repository.DocumentRepository;
+import com.aidea.aidea.domain.draft.entity.Draft;
+import com.aidea.aidea.domain.draft.entity.DraftStatus;
+import com.aidea.aidea.domain.draft.repository.DraftRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DraftAsyncExecutor {
+
+    private final DraftRepository draftRepository;
+    private final DocumentRepository documentRepository;
+    private final FeedbackEventPublisher eventPublisher;
+    private final ObjectMapper objectMapper;
+
+    @Value("${gemini.api-key}")  private String apiKey;
+    @Value("${gemini.base-url}") private String geminiBaseUrl;
+    @Value("${gemini.model}")    private String geminiModel;
+
+    private final RestClient restClient = RestClient.builder()
+            .requestFactory(new JdkClientHttpRequestFactory(
+                    HttpClient.newBuilder()
+                            .connectTimeout(Duration.ofSeconds(10))
+                            .build()))
+            .build();
+
+    @Async
+    @Transactional
+    public void generateDraftAsync(String draftId) {
+        log.info("[DRAFT] 생성 시작 draftId={} thread={}", draftId, Thread.currentThread().getName());
+
+        Draft draft = draftRepository.findById(draftId)
+                .orElseThrow(() -> new IllegalStateException("draft not found: " + draftId));
+        Document document = draft.getDocument();
+
+        try {
+            String prompt = buildPrompt(document.getType());
+            String content = callGeminiApi(prompt);
+
+            draft.setContent(content);
+            draft.setStatus(DraftStatus.DONE);
+            document.setStatus(DocumentAiStatus.IDLE);
+
+            publishEvent(document.getId(), "draft:ready", Map.of("content", content));
+            log.info("[DRAFT] 생성 완료 draftId={}", draftId);
+
+        } catch (Exception e) {
+            log.error("[DRAFT] 생성 실패 draftId={}", draftId, e);
+
+            draft.setErrorMessage("초안 생성에 실패했습니다.");
+            draft.setStatus(DraftStatus.FAILED);
+            document.setStatus(DocumentAiStatus.IDLE);
+
+            publishEvent(document.getId(), "draft:error",
+                    Map.of("errorMessage", "초안 생성에 실패했습니다."));
+        }
+    }
+
+    private String buildPrompt(com.aidea.aidea.domain.documents.entity.DocumentType type) {
+        String typeInstruction = switch (type) {
+            case IDEA          -> "서비스 아이디어 기획서 (핵심 가치, 타깃 사용자, 차별점 포함)";
+            case PLAN          -> "프로젝트 계획서 (목표, 주요 기능, 개발 단계, 예상 일정 포함)";
+            case USER_SCENARIO -> "유저 시나리오 문서 (주요 사용자 유형, Use Case 3~5개 포함)";
+            case API_SPEC      -> "REST API 명세서 (주요 엔드포인트, 요청/응답 형식 포함)";
+            case ERD           -> "ERD 설명 문서 (주요 엔티티, 핵심 필드, 관계 포함)";
+        };
+
+        return """
+            [ROLE] 너는 IT 스타트업 기획 전문가야.
+            [TASK] 새 팀 프로젝트의 %s 초안을 마크다운으로 작성해줘.
+            [INSTRUCTION]
+            - 실제로 채워야 할 내용은 [TODO] 형태로 표시
+            - 섹션 제목은 구체적으로 작성
+            - 전체 길이 1000자
+            """.formatted(typeInstruction);
+    }
+
+    private String callGeminiApi(String prompt) throws Exception {
+        Map<String, Object> requestBody = Map.of(
+                "contents", List.of(Map.of("parts", List.of(Map.of("text", prompt)))),
+                "generationConfig", Map.of(
+                        "responseMimeType", "application/json",
+                        "responseSchema", Map.of(
+                                "type", "OBJECT",
+                                "properties", Map.of("content", Map.of("type", "STRING")),
+                                "required", List.of("content")
+                        ),
+                        "maxOutputTokens", 4096
+                )
+        );
+
+        String url = geminiBaseUrl + "/models/" + geminiModel + ":generateContent?key=" + apiKey;
+
+        Map response = restClient.post()
+                .uri(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(requestBody)
+                .retrieve()
+                .body(Map.class);
+
+        List<Map<String, Object>> candidates = (List<Map<String, Object>>) response.get("candidates");
+        Map<String, Object> content = (Map<String, Object>) candidates.get(0).get("content");
+        List<Map<String, Object>> parts = (List<Map<String, Object>>) content.get("parts");
+        String json = (String) parts.get(0).get("text");
+
+        Map<String, String> result = objectMapper.readValue(json, Map.class);
+        return result.get("content");
+    }
+
+    private void publishEvent(String documentId, String type, Map<String, Object> payload) {
+        try {
+            Map<String, Object> event = new HashMap<>(payload);
+            event.put("type", type);
+            event.put("documentId", documentId);
+            eventPublisher.publishToDocument(documentId, objectMapper.writeValueAsString(event));
+        } catch (Exception e) {
+            log.error("[DRAFT] 이벤트 발행 실패 type={}", type, e);
+        }
+    }
+}

--- a/src/main/java/com/aidea/aidea/domain/draft/service/DraftService.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/service/DraftService.java
@@ -1,0 +1,51 @@
+package com.aidea.aidea.domain.draft.service;
+
+import com.aidea.aidea.domain.documents.entity.Document;
+import com.aidea.aidea.domain.documents.entity.DocumentAiStatus;
+import com.aidea.aidea.domain.documents.repository.DocumentRepository;
+import com.aidea.aidea.domain.draft.entity.Draft;
+import com.aidea.aidea.domain.draft.entity.DraftStatus;
+import com.aidea.aidea.domain.draft.repository.DraftRepository;
+import com.aidea.aidea.global.exception.CustomException;
+import com.aidea.aidea.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DraftService {
+
+    private final DraftRepository draftRepository;
+    private final DocumentRepository documentRepository;
+    private final DraftAsyncExecutor draftAsyncExecutor;
+
+    @Transactional
+    public void triggerDraftGeneration(String documentId) {
+        Document document = documentRepository.findById(documentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DOCUMENT_NOT_FOUND));
+
+        if (draftRepository.existsByDocumentIdAndStatus(documentId, DraftStatus.PENDING)) {
+            return;
+        }
+
+        document.setStatus(DocumentAiStatus.DRAFT);
+
+        Draft draft = Draft.create(UUID.randomUUID().toString(), document);
+        draftRepository.save(draft);
+
+        String draftId = draft.getId();
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                draftAsyncExecutor.generateDraftAsync(draftId);
+            }
+        });
+    }
+}

--- a/src/main/java/com/aidea/aidea/domain/teamspace/service/TeamSpaceService.java
+++ b/src/main/java/com/aidea/aidea/domain/teamspace/service/TeamSpaceService.java
@@ -4,6 +4,7 @@ import com.aidea.aidea.domain.auth.entity.User;
 import com.aidea.aidea.domain.auth.repository.UserRepository;
 import com.aidea.aidea.domain.documents.entity.Document;
 import com.aidea.aidea.domain.documents.repository.DocumentRepository;
+import com.aidea.aidea.domain.draft.service.DraftService;
 import com.aidea.aidea.domain.teamspace.dto.*;
 import com.aidea.aidea.domain.teamspace.entity.MemberRole;
 import com.aidea.aidea.domain.teamspace.entity.TeamSpace;
@@ -29,6 +30,7 @@ public class TeamSpaceService {
     private final TeamspaceMemberRepository teamspaceMemberRepository;
     private final DocumentRepository documentRepository;
     private final UserRepository userRepository;
+    private final DraftService draftService;
 
     @Transactional
     public TeamSpaceCreateResponse create(TeamSpaceCreateRequest request, Long userId) {
@@ -60,6 +62,7 @@ public class TeamSpaceService {
                     .map(type -> Document.create(UUID.randomUUID().toString(), saved, type, type.name()))
                     .collect(Collectors.toList());
             documentRepository.saveAll(documents);
+            documents.forEach(doc -> draftService.triggerDraftGeneration(doc.getId()));
         }
 
         return TeamSpaceCreateResponse.builder()

--- a/src/main/java/com/aidea/aidea/global/exception/ErrorCode.java
+++ b/src/main/java/com/aidea/aidea/global/exception/ErrorCode.java
@@ -37,7 +37,12 @@ public enum ErrorCode {
     // ===== AI 피드백 (Feedback) =====
     FEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "FEEDBACK_NOT_FOUND", "피드백을 찾을 수 없습니다."),
     FEEDBACK_IN_PROGRESS(HttpStatus.CONFLICT, "FEEDBACK_IN_PROGRESS", "이미 진행 중인 피드백이 있습니다."),
-    FEEDBACK_INVALID_STATUS(HttpStatus.BAD_REQUEST, "FEEDBACK_INVALID_STATUS", "현재 상태에서는 해당 작업을 수행할 수 없습니다.");
+    FEEDBACK_INVALID_STATUS(HttpStatus.BAD_REQUEST, "FEEDBACK_INVALID_STATUS", "현재 상태에서는 해당 작업을 수행할 수 없습니다."),
+
+    // ===== 초안 (Draft) =====
+    DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "DRAFT_NOT_FOUND", "초안을 찾을 수 없습니다."),
+    DRAFT_IN_PROGRESS(HttpStatus.CONFLICT, "DRAFT_IN_PROGRESS", "초안 생성 중에는 피드백을 요청할 수 없습니다."),
+    DRAFT_ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "DRAFT_ALREADY_IN_PROGRESS", "이미 초안 생성 중입니다.");
 
     private final HttpStatus httpStatus;  // HTTP 상태 코드 (404, 401 등)
     private final String code;            // 우리가 정한 에러 코드 문자열

--- a/src/main/resources/swagger.yml
+++ b/src/main/resources/swagger.yml
@@ -32,7 +32,6 @@ tags:
   - name: Auth
     description: 인증 (소셜 로그인, 토큰 관리)
   - name: Teamspace
-
     description: 팀스페이스 생성, 조회, 관리
   - name: Member
     description: 멤버 조회, 초대, 추방, 초대 수락/취소
@@ -40,6 +39,8 @@ tags:
     description: 문서 CRUD 및 내보내기
   - name: Feedback
     description: AI 피드백 요청 및 수락
+  - name: Draft
+    description: 팀 스페이스 생성 시 문서 초안 생성
 
 components:
   securitySchemes:
@@ -268,6 +269,28 @@ components:
         status:
           type: string
           enum: [PENDING, DONE, ACCEPTED]
+
+    DraftResponse:
+      type: object
+      properties:
+        draftId:
+          type: string
+        documentId:
+          type: string
+        status:
+          type: string
+          enum: [PENDING, DONE, FAILED]
+        content:
+          type: string
+          nullable: true
+          description: "AI 생성 마크다운 (DONE 상태일 때만 값 있음)"
+        errorMessage:
+          type: string
+          nullable: true
+          description: "실패 사유 (FAILED 상태일 때만 값 있음)"
+        createdAt:
+          type: string
+          format: date-time
 
     ErrorResponse:
       type: object
@@ -1139,3 +1162,122 @@ paths:
                   documentId: "doc_001"
                   yjsBinary: "base64_encoded_after_snapshot..."
 
+  # ===== Draft =====
+  /api/documents/{docId}/draft:
+    post:
+      tags: [Draft]
+      summary: AI 초안 재생성 요청
+      description: |
+        문서 타입에 맞는 AI 초안을 비동기로 생성합니다.
+
+        **서버 동작:**
+        1. Document.status → DRAFT
+        2. drafts 테이블에 INSERT (status: PENDING)
+        3. 202 Accepted 응답 반환
+        4. 백그라운드에서 Gemini API 호출
+        5. 성공: draft.content 저장, Document.status → IDLE, WebSocket `draft:ready` 발행
+        6. 실패: draft.errorMessage 저장, Document.status → IDLE, WebSocket `draft:error` 발행
+
+        **WebSocket 이벤트:**
+        - `draft:ready` — `{ type, documentId, content }`
+        - `draft:error` — `{ type, documentId, errorMessage }`
+
+        **주의:** DRAFT 상태 중에는 AI 피드백 요청이 409로 거부됩니다.
+      parameters:
+        - name: docId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '202':
+          description: 초안 생성 요청 접수 (비동기 처리 중)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+              example:
+                success: true
+                code: "200"
+                message: "초안을 생성하고 있습니다."
+                data: null
+        '404':
+          description: 문서 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                code: "DOCUMENT_NOT_FOUND"
+                message: "문서를 찾을 수 없습니다."
+        '409':
+          description: 이미 초안 생성 중
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                code: "DRAFT_ALREADY_IN_PROGRESS"
+                message: "이미 초안 생성이 진행 중입니다."
+
+    get:
+      tags: [Draft]
+      summary: AI 초안 조회
+      description: |
+        문서의 AI 초안을 조회합니다. status가 PENDING이면 아직 생성 중입니다.
+        완료/실패 여부는 WebSocket 이벤트로도 수신할 수 있습니다.
+      parameters:
+        - name: docId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 초안 조회 성공
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/DraftResponse'
+              examples:
+                done:
+                  summary: 생성 완료
+                  value:
+                    success: true
+                    message: "success"
+                    data:
+                      draftId: "d1a2b3c4"
+                      documentId: "doc_001"
+                      status: "DONE"
+                      content: "# 서비스 아이디어\n\n## 핵심 가치\n[TODO] ..."
+                      errorMessage: null
+                      createdAt: "2026-05-28T10:00:00"
+                failed:
+                  summary: 생성 실패
+                  value:
+                    success: true
+                    message: "success"
+                    data:
+                      draftId: "d1a2b3c4"
+                      documentId: "doc_001"
+                      status: "FAILED"
+                      content: null
+                      errorMessage: "초안 생성에 실패했습니다."
+                      createdAt: "2026-05-28T10:00:00"
+        '404':
+          description: 초안 없음 (아직 생성 요청 안 됨)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                code: "DRAFT_NOT_FOUND"
+                message: "초안을 찾을 수 없습니다."


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
> - Closes #77 


<br>

## 📝 작업 내용
> 팀스페이스 생성 시 선택한 문서 타입별로 Gemini AI가 초안을 자동으로 생성하는 기능을 구현



<br>

## 테스트 및 검증 내용

 - 팀스페이스 생성 후 서버 로그에서 [DRAFT] 생성 시작 → [DRAFT] 생성 완료 순서로 출력 확인

  - Gemini API 정상 응답 시 DB drafts 테이블에 status=DONE, content 마크다운 저장 확인
  
  - WebSocket 연결 클라이언트에 draft:ready 이벤트 수신 확인 (type, documentId, content 필드 포함)
  
  - WebSocket 연결 전 초안이 완료된 경우 doc:init 응답의 activeDraft.status=DONE, activeDraft.content 정상 포함 확인
  
  - 동일 문서에 초안 중복 생성 요청 시 PENDING 상태 체크로 중복 실행 차단 확인
  
  - Gemini API 실패 시 status=FAILED, errorMessage 저장 및 draft:error 이벤트 발행 확인



