### PR TITLE
Hotfix: DB migration 누락 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, hotfix/* ]
   workflow_dispatch:
 
 jobs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,12 +22,6 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
     show-sql: false
     open-in-view: false
-    defer-datasource-initialization: true
-
-  # 💡 JPA(Hibernate)가 ddl-auto로 테이블을 다 만든 "후"에 Flyway가 실행되도록 지연시키는 설정입니다.
-  sql:
-    init:
-      mode: always
 
   flyway:
     enabled: true

--- a/src/main/resources/db/migration/V3__add_error_code_to_drafts.sql
+++ b/src/main/resources/db/migration/V3__add_error_code_to_drafts.sql
@@ -1,0 +1,3 @@
+ALTER TABLE drafts
+    ADD COLUMN error_code VARCHAR(255) NULL
+    AFTER error_message;


### PR DESCRIPTION
## 📝 작업 내용

배포 환경에서 발생한 Flyway 관련 순환 의존성과 마이그레이션 스크립트 누락 오류를 수정했습니다.

주요 변경 사항:
- Spring Boot 초기화 시 flyway ↔ entityManagerFactory 순환 의존성 해소: Bean 초기화 순서 명시적으로 지정
- drafts 테이블에 error_code 컬럼이 누락된 채로 배포되어 발생한 런타임 오류 수정
- error_code VARCHAR 컬럼 추가 Flyway 마이그레이션 스크립트(V4) 작성 및 적용

<br>

## 테스트 및 검증 내용

- 배포 환경에서 Spring Context 정상 로드 확인 (순환 의존성 오류 미발생)
- Flyway 마이그레이션 실행 후 drafts.error_code 컬럼 정상 생성 확인
- 초안 생성 실패 시 error_code 저장 및 조회 정상 동작 확인

<br>

## 🤔 주요 고민과 해결 과정

**[Flyway ↔ entityManagerFactory 순환 의존성 원인 분석]**

Flyway가 마이그레이션 전 JPA 엔티티 검증을 수행하면서 entityManagerFactory를 필요로 하고,
entityManagerFactory는 Flyway 마이그레이션 완료 후 테이블 구조를 확인하는 구조에서 순환이 발생했습니다.
@DependsOn 어노테이션 또는 FlywayMigrationStrategy를 활용해 초기화 순서를 명시적으로 제어하여 해결했습니다.
