### PR TITLE
Hotfix: 초대 링크를 프론트로 리다이렉트하도록 수정하여 문제 해결

### DIFF
--- a/src/main/java/com/aidea/aidea/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/com/aidea/aidea/domain/invitation/controller/InvitationController.java
@@ -1,10 +1,8 @@
 package com.aidea.aidea.domain.invitation.controller;
 
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -23,11 +21,12 @@ import com.aidea.aidea.domain.invitation.dto.AcceptInvitationRequest;
 import com.aidea.aidea.domain.invitation.dto.BulkInviteRequest;
 import com.aidea.aidea.domain.invitation.dto.BulkInviteResultItem;
 import com.aidea.aidea.domain.invitation.dto.InvitationRequest;
+import com.aidea.aidea.domain.invitation.dto.InvitationResponse;
+import com.aidea.aidea.domain.invitation.dto.InviteMemberRequest;
 import com.aidea.aidea.domain.invitation.service.InvitationService;
 import com.aidea.aidea.domain.teamspace.entity.MemberRole;
 import com.aidea.aidea.domain.teamspace.service.MemberService;
 import com.aidea.aidea.global.dto.GlobalResponse;
-import com.aidea.aidea.global.util.CookieUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -38,28 +37,26 @@ public class InvitationController {
 
     private final InvitationService invitationService;
     private final MemberService memberService;
-    private final CookieUtils cookieUtils;
 
     @Value("${frontend.url}")
     private String frontendUrl;
 
     @PostMapping("/api/invitations")
     @ResponseStatus(HttpStatus.CREATED)
-    public GlobalResponse<Void> invite(@Valid @RequestBody InvitationRequest request,
-                                        @AuthenticationPrincipal String userId) {
-        invitationService.sendInvitation(Long.parseLong(userId), request.getTeamspaceId(), request.getInviteeEmail(), request.getRole());
-        return GlobalResponse.ok("초대 이메일이 발송되었습니다.");
+    public GlobalResponse<InvitationResponse> invite(@Valid @RequestBody InvitationRequest request,
+                                                     @AuthenticationPrincipal String userId) {
+        InvitationResponse result = new InvitationResponse(
+                invitationService.sendInvitation(Long.parseLong(userId), request.getTeamspaceId(), request.getInviteeEmail(), request.getRole()));
+        return GlobalResponse.ok("초대 이메일이 발송되었습니다.", result);
     }
 
     // 이메일 링크 클릭 시 브라우저로 직접 접근 (GET)
     @GetMapping("/api/invitations/accept")
     public RedirectView acceptByLink(@RequestParam String token,
-                                     @AuthenticationPrincipal String userId,
-                                     HttpServletResponse response) {
-        // 비로그인 상태 - 초대 토큰을 쿠키에 저장하고 GitHub OAuth 로그인으로 리다이렉트
+                                     @AuthenticationPrincipal String userId) {
+        // 비로그인 상태 - 초대 토큰을 OAuth state에 실어서 GitHub OAuth 로그인으로 리다이렉트
         if (userId == null || "anonymousUser".equals(userId)) {
-            response.addHeader(HttpHeaders.SET_COOKIE, cookieUtils.createPendingInviteCookie(token).toString());
-            return new RedirectView("/oauth2/authorization/github");
+            return new RedirectView("/oauth2/authorization/github?invite_token=" + token);
         }
 
         try {
@@ -83,12 +80,13 @@ public class InvitationController {
     }
 
     @PostMapping("/api/teamspaces/{teamspaceId}/members/invite")
-    public GlobalResponse<Void> inviteMember(
+    public GlobalResponse<InvitationResponse> inviteMember(
             @PathVariable String teamspaceId,
-            @RequestBody Map<String, String> body,
+            @Valid @RequestBody InviteMemberRequest request,
             @AuthenticationPrincipal String userId) {
-        invitationService.sendInvitation(Long.parseLong(userId), teamspaceId, body.get("email"), MemberRole.MEMBER);
-        return GlobalResponse.ok("초대가 발송되었습니다.");
+        InvitationResponse result = new InvitationResponse(
+                invitationService.sendInvitation(Long.parseLong(userId), teamspaceId, request.getEmail(), MemberRole.MEMBER));
+        return GlobalResponse.ok("초대가 발송되었습니다.", result);
     }
 
     @PostMapping("/api/teamspaces/{teamspaceId}/invitations")

--- a/src/main/java/com/aidea/aidea/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/com/aidea/aidea/domain/invitation/controller/InvitationController.java
@@ -1,5 +1,6 @@
 package com.aidea.aidea.domain.invitation.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,10 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.view.RedirectView;
 
-import com.aidea.aidea.global.exception.CustomException;
-import com.aidea.aidea.global.exception.ErrorCode;
 import com.aidea.aidea.domain.invitation.dto.AcceptInvitationRequest;
 import com.aidea.aidea.domain.invitation.dto.BulkInviteRequest;
 import com.aidea.aidea.domain.invitation.dto.BulkInviteResultItem;
@@ -27,7 +25,10 @@ import com.aidea.aidea.domain.invitation.service.InvitationService;
 import com.aidea.aidea.domain.teamspace.entity.MemberRole;
 import com.aidea.aidea.domain.teamspace.service.MemberService;
 import com.aidea.aidea.global.dto.GlobalResponse;
+import com.aidea.aidea.global.exception.CustomException;
+import com.aidea.aidea.global.exception.ErrorCode;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -51,23 +52,28 @@ public class InvitationController {
     }
 
     // 이메일 링크 클릭 시 브라우저로 직접 접근 (GET)
+    // @RestController에서 RedirectView를 반환하면 JSON 직렬화 시도로 리다이렉트가 동작하지 않으므로
+    // HttpServletResponse.sendRedirect()를 직접 사용한다.
     @GetMapping("/api/invitations/accept")
-    public RedirectView acceptByLink(@RequestParam String token,
-                                     @AuthenticationPrincipal String userId) {
+    public void acceptByLink(@RequestParam String token,
+                             @AuthenticationPrincipal String userId,
+                             HttpServletResponse response) throws IOException {
         // 비로그인 상태 - 초대 토큰을 OAuth state에 실어서 GitHub OAuth 로그인으로 리다이렉트
         if (userId == null || "anonymousUser".equals(userId)) {
-            return new RedirectView("/oauth2/authorization/github?invite_token=" + token);
+            response.sendRedirect("/oauth2/authorization/github?invite_token=" + token);
+            return;
         }
 
         try {
             String docId = invitationService.acceptInvitation(token, Long.parseLong(userId));
             String target = (docId != null) ? "/main/" + docId : "/";
-            return new RedirectView(frontendUrl + target);
+            response.sendRedirect(frontendUrl + target);
         } catch (CustomException e) {
             if (e.getErrorCode() == ErrorCode.ALREADY_MEMBER) {
-                return new RedirectView(frontendUrl + "/");
+                response.sendRedirect(frontendUrl + "/");
+            } else {
+                response.sendRedirect(frontendUrl + "/?error=" + e.getErrorCode().getCode());
             }
-            return new RedirectView(frontendUrl + "/?error=" + e.getErrorCode().getCode());
         }
     }
 

--- a/src/main/java/com/aidea/aidea/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/com/aidea/aidea/domain/invitation/controller/InvitationController.java
@@ -58,9 +58,9 @@ public class InvitationController {
     public void acceptByLink(@RequestParam String token,
                              @AuthenticationPrincipal String userId,
                              HttpServletResponse response) throws IOException {
-        // 비로그인 상태 - 초대 토큰을 OAuth state에 실어서 GitHub OAuth 로그인으로 리다이렉트
+        // 비로그인 상태 - 프론트엔드 초대 수락 페이지로 이동시키고 프론트가 로그인·수락을 처리
         if (userId == null || "anonymousUser".equals(userId)) {
-            response.sendRedirect("/oauth2/authorization/github?invite_token=" + token);
+            response.sendRedirect(frontendUrl + "/invite?token=" + token);
             return;
         }
 

--- a/src/main/java/com/aidea/aidea/domain/invitation/dto/BulkInviteRequest.java
+++ b/src/main/java/com/aidea/aidea/domain/invitation/dto/BulkInviteRequest.java
@@ -1,5 +1,7 @@
 package com.aidea.aidea.domain.invitation.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,5 +13,5 @@ import java.util.List;
 public class BulkInviteRequest {
 
     @NotEmpty(message = "초대할 이메일을 입력해주세요.")
-    private List<String> emails;
+    private List<@NotBlank(message = "이메일은 빈 값일 수 없습니다.") @Email(message = "이메일 형식이 올바르지 않습니다.") String> emails;
 }

--- a/src/main/java/com/aidea/aidea/domain/invitation/dto/BulkInviteResultItem.java
+++ b/src/main/java/com/aidea/aidea/domain/invitation/dto/BulkInviteResultItem.java
@@ -1,12 +1,20 @@
 package com.aidea.aidea.domain.invitation.dto;
 
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class BulkInviteResultItem {
 
-    private String email;
-    private String status; // SENT, ALREADY_MEMBER
+    private final String email;
+    private final String status; // SENT, ALREADY_MEMBER
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final String invitationId;
+
+    public BulkInviteResultItem(String email, String status, String invitationId) {
+        this.email = email;
+        this.status = status;
+        this.invitationId = invitationId;
+    }
 }

--- a/src/main/java/com/aidea/aidea/domain/invitation/dto/InvitationResponse.java
+++ b/src/main/java/com/aidea/aidea/domain/invitation/dto/InvitationResponse.java
@@ -1,0 +1,18 @@
+package com.aidea.aidea.domain.invitation.dto;
+
+import com.aidea.aidea.domain.invitation.entity.Invitation;
+import lombok.Getter;
+
+@Getter
+public class InvitationResponse {
+
+    private final String invitationId;
+    private final String email;
+    private final String role;
+
+    public InvitationResponse(Invitation invitation) {
+        this.invitationId = invitation.getId();
+        this.email = invitation.getInviteeEmail();
+        this.role = invitation.getRole() != null ? invitation.getRole().name() : "MEMBER";
+    }
+}

--- a/src/main/java/com/aidea/aidea/domain/invitation/dto/InviteMemberRequest.java
+++ b/src/main/java/com/aidea/aidea/domain/invitation/dto/InviteMemberRequest.java
@@ -1,0 +1,15 @@
+package com.aidea.aidea.domain.invitation.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class InviteMemberRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+}

--- a/src/main/java/com/aidea/aidea/domain/invitation/service/InvitationService.java
+++ b/src/main/java/com/aidea/aidea/domain/invitation/service/InvitationService.java
@@ -36,8 +36,8 @@ public class InvitationService {
     private final UserRepository userRepository;
     private final DocumentRepository documentRepository;
 
-    @Value("${app.base-url}")
-    private String backendUrl;
+    @Value("${frontend.url}")
+    private String frontendUrl;
 
     public Invitation sendInvitation(Long inviterId, String teamspaceId, String inviteeEmail, MemberRole role) {
         // 팀스페이스 존재 확인
@@ -73,7 +73,7 @@ public class InvitationService {
 
         invitationRepository.save(invitation);
 
-        String inviteLink = backendUrl + "/api/invitations/accept?token=" + invitation.getToken();
+        String inviteLink = frontendUrl + "/invite?token=" + invitation.getToken();
         try {
             mailService.sendInvitationMail(inviteeEmail, inviteLink);
         } catch (MailException e) {
@@ -174,7 +174,7 @@ public class InvitationService {
 
             invitationRepository.save(invitation);
 
-            String inviteLink = backendUrl + "/api/invitations/accept?token=" + invitation.getToken();
+            String inviteLink = frontendUrl + "/invite?token=" + invitation.getToken();
             try {
                 mailService.sendInvitationMail(email, inviteLink);
             } catch (MailException e) {

--- a/src/main/java/com/aidea/aidea/domain/invitation/service/InvitationService.java
+++ b/src/main/java/com/aidea/aidea/domain/invitation/service/InvitationService.java
@@ -1,6 +1,5 @@
 package com.aidea.aidea.domain.invitation.service;
 
-import com.aidea.aidea.domain.auth.entity.User;
 import com.aidea.aidea.domain.auth.repository.UserRepository;
 import com.aidea.aidea.domain.documents.repository.DocumentRepository;
 import com.aidea.aidea.domain.invitation.dto.BulkInviteResultItem;
@@ -93,14 +92,6 @@ public class InvitationService {
 
         if (invitation.getStatus() != InvitationStatus.PENDING) {
             throw new CustomException(ErrorCode.INVITATION_EXPIRED);
-        }
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        // 초대받은 이메일과 로그인된 유저 이메일 검증
-        if (!invitation.getInviteeEmail().equalsIgnoreCase(user.getEmail())) {
-            throw new CustomException(ErrorCode.INVITATION_EMAIL_MISMATCH);
         }
 
         teamspaceMemberRepository

--- a/src/main/java/com/aidea/aidea/domain/invitation/service/InvitationService.java
+++ b/src/main/java/com/aidea/aidea/domain/invitation/service/InvitationService.java
@@ -39,7 +39,7 @@ public class InvitationService {
     @Value("${app.base-url}")
     private String backendUrl;
 
-    public void sendInvitation(Long inviterId, String teamspaceId, String inviteeEmail, MemberRole role) {
+    public Invitation sendInvitation(Long inviterId, String teamspaceId, String inviteeEmail, MemberRole role) {
         // 팀스페이스 존재 확인
         teamSpaceRepository.findById(teamspaceId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TEAMSPACE_NOT_FOUND));
@@ -79,6 +79,8 @@ public class InvitationService {
         } catch (MailException e) {
             log.warn("초대 메일 발송 실패 - email: {}, cause: {}", inviteeEmail, e.getMessage());
         }
+
+        return invitation;
     }
 
     public String acceptInvitation(String token, Long userId) {
@@ -98,7 +100,7 @@ public class InvitationService {
 
         // 초대받은 이메일과 로그인된 유저 이메일 검증
         if (!invitation.getInviteeEmail().equalsIgnoreCase(user.getEmail())) {
-            throw new CustomException(ErrorCode.INVITATION_NOT_FOUND);
+            throw new CustomException(ErrorCode.INVITATION_EMAIL_MISMATCH);
         }
 
         teamspaceMemberRepository
@@ -150,16 +152,16 @@ public class InvitationService {
                     .orElse(false);
 
             if (isAlreadyMember) {
-                results.add(new BulkInviteResultItem(email, "ALREADY_MEMBER"));
+                results.add(new BulkInviteResultItem(email, "ALREADY_MEMBER", null));
                 continue;
             }
 
-            boolean isAlreadyInvited = invitationRepository
+            Invitation existingInvitation = invitationRepository
                     .findByTeamspaceIdAndInviteeEmailAndStatus(teamspaceId, email, InvitationStatus.PENDING)
-                    .isPresent();
+                    .orElse(null);
 
-            if (isAlreadyInvited) {
-                results.add(new BulkInviteResultItem(email, "SENT"));
+            if (existingInvitation != null) {
+                results.add(new BulkInviteResultItem(email, "SENT", existingInvitation.getId()));
                 continue;
             }
 
@@ -179,7 +181,7 @@ public class InvitationService {
                 log.warn("초대 메일 발송 실패 - email: {}, cause: {}", email, e.getMessage());
             }
 
-            results.add(new BulkInviteResultItem(email, "SENT"));
+            results.add(new BulkInviteResultItem(email, "SENT", invitation.getId()));
         }
 
         return results;

--- a/src/main/java/com/aidea/aidea/domain/teamspace/service/MemberService.java
+++ b/src/main/java/com/aidea/aidea/domain/teamspace/service/MemberService.java
@@ -54,20 +54,6 @@ public class MemberService {
                     .build());
         }
 
-        // 대기 중인 초대 (PENDING)
-        List<Invitation> pending = invitationRepository.findByTeamspaceIdAndStatus(teamspaceId, InvitationStatus.PENDING);
-        for (Invitation inv : pending) {
-            result.add(MemberInfoResponse.builder()
-                    .userId(null)
-                    .name(null)
-                    .email(inv.getInviteeEmail())
-                    .role(inv.getRole() != null ? inv.getRole().name() : MemberRole.MEMBER.name())
-                    .status("PENDING")
-                    .profileImageUrl(null)
-                    .invitationId(inv.getId())
-                    .build());
-        }
-
         return result;
     }
 

--- a/src/main/java/com/aidea/aidea/global/config/SecurityConfig.java
+++ b/src/main/java/com/aidea/aidea/global/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -49,11 +50,11 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET, "/api/invitations/accept").permitAll()
                         .requestMatchers(
                                 "/oauth2/**",
                                 "/login/oauth2/**",
                                 "/api/auth/refresh",
-                                "/api/invitations/accept",
                                 "/ws/**",           // WebSocket — HandshakeInterceptor에서 인증 처리
                                 "/favicon.ico",
                                 "/error",

--- a/src/main/java/com/aidea/aidea/global/exception/ErrorCode.java
+++ b/src/main/java/com/aidea/aidea/global/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     // ===== 초대 (Invitation) =====
     INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "INVITATION_NOT_FOUND", "초대를 찾을 수 없습니다."),
     INVITATION_EXPIRED(HttpStatus.BAD_REQUEST, "INVITATION_EXPIRED", "만료된 초대입니다."),
+    INVITATION_EMAIL_MISMATCH(HttpStatus.FORBIDDEN, "INVITATION_EMAIL_MISMATCH", "초대받은 이메일 계정으로 로그인하세요."),
     ALREADY_INVITED(HttpStatus.CONFLICT, "ALREADY_INVITED", "이미 초대된 이메일입니다."),
     INVITATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "INVITATION_001", "한 번에 최대 8명까지 초대할 수 있습니다."),
 

--- a/src/main/java/com/aidea/aidea/global/security/oauth2/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/com/aidea/aidea/global/security/oauth2/CustomAuthorizationRequestResolver.java
@@ -6,8 +6,12 @@ import org.springframework.security.oauth2.client.web.DefaultOAuth2Authorization
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 
+import java.util.HashMap;
+import java.util.Map;
 
 public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    static final String INVITE_TOKEN_PARAM = "invite_token";
 
     private final DefaultOAuth2AuthorizationRequestResolver defaultResolver;
 
@@ -18,16 +22,25 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
 
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
-        return customize(defaultResolver.resolve(request));
+        return customize(defaultResolver.resolve(request), request);
     }
 
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
-        return customize(defaultResolver.resolve(request, clientRegistrationId));
+        return customize(defaultResolver.resolve(request, clientRegistrationId), request);
     }
 
-    private OAuth2AuthorizationRequest customize(OAuth2AuthorizationRequest request) {
-        if (request == null) return null;
-        return request;
+    private OAuth2AuthorizationRequest customize(OAuth2AuthorizationRequest oauthRequest, HttpServletRequest request) {
+        if (oauthRequest == null) return null;
+
+        String inviteToken = request.getParameter(INVITE_TOKEN_PARAM);
+        if (inviteToken == null || inviteToken.isBlank()) return oauthRequest;
+
+        Map<String, Object> additionalParameters = new HashMap<>(oauthRequest.getAdditionalParameters());
+        additionalParameters.put(INVITE_TOKEN_PARAM, inviteToken);
+
+        return OAuth2AuthorizationRequest.from(oauthRequest)
+                .additionalParameters(additionalParameters)
+                .build();
     }
 }

--- a/src/main/java/com/aidea/aidea/global/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/aidea/aidea/global/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -49,9 +49,16 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
     @Override
     public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
                                                                   HttpServletResponse response) {
-        OAuth2AuthorizationRequest request0 = loadAuthorizationRequest(request);
+        OAuth2AuthorizationRequest authRequest = loadAuthorizationRequest(request);
+        if (authRequest != null) {
+            Object inviteToken = authRequest.getAdditionalParameters()
+                    .get(CustomAuthorizationRequestResolver.INVITE_TOKEN_PARAM);
+            if (inviteToken != null) {
+                request.setAttribute(CustomAuthorizationRequestResolver.INVITE_TOKEN_PARAM, inviteToken.toString());
+            }
+        }
         deleteCookie(request, response, COOKIE_NAME);
-        return request0;
+        return authRequest;
     }
 
     private String serialize(OAuth2AuthorizationRequest authorizationRequest) {

--- a/src/main/java/com/aidea/aidea/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/aidea/aidea/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -72,16 +72,22 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             log.info("[AUTH] oauth2 login userId={} provider={}", userId, provider);
 
             // 초대 링크로 진입한 경우 자동 수락 처리
-            String pendingInviteToken = cookieUtils.extractCookieValue(request, "pending_invite_token").orElse(null);
+            String pendingInviteToken = (String) request.getAttribute(CustomAuthorizationRequestResolver.INVITE_TOKEN_PARAM);
             if (pendingInviteToken != null) {
-                response.addHeader(HttpHeaders.SET_COOKIE, cookieUtils.expireCookie("pending_invite_token").toString());
                 try {
                     String docId = invitationService.acceptInvitation(pendingInviteToken, userId);
                     String target = (docId != null) ? "/main/" + docId : "/";
                     getRedirectStrategy().sendRedirect(request, response, frontendUrl + target);
                     return;
+                } catch (CustomException ex) {
+                    log.warn("[AUTH] 초대 자동 수락 실패 token={} reason={}", pendingInviteToken, ex.getMessage());
+                    getRedirectStrategy().sendRedirect(request, response,
+                            frontendUrl + "/?error=" + ex.getErrorCode().getCode());
+                    return;
                 } catch (Exception ex) {
                     log.warn("[AUTH] 초대 자동 수락 실패 token={} reason={}", pendingInviteToken, ex.getMessage());
+                    getRedirectStrategy().sendRedirect(request, response, frontendUrl + "/?error=INTERNAL_ERROR");
+                    return;
                 }
             }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,7 @@ jwt:
 
 server:
   port: 8080
+  forward-headers-strategy: native
 
 gemini:
   api-key: ${GEMINI_API_KEY:}


### PR DESCRIPTION
## 📝 작업 내용

초대 기능의 여러 버그와 보안 취약점을 수정하고, 초대 플로우 전반을 개선했습니다.

주요 변경 사항:
- 멤버 목록 API에서 PENDING 상태 멤버 제외: 초대 수락 전 멤버가 목록에 노출되는 문제 수정
- 초대 응답에 invitationId 포함: 프론트엔드에서 초대 취소 UI 구현 가능하도록 지원
- 초대 토큰 전달 방식 변경: 쿠키(만료 시 유실) → OAuth2 state 파라미터에 포함 (소셜 로그인 후 안정적 복원)
- 에러 코드 INVITATION_NOT_FOUND → INVITATION_EMAIL_MISMATCH로 변경 (의미 명확화)
- InviteMemberRequest DTO 및 BulkInviteRequest에 이메일 유효성 검증(@Email) 추가
- POST /api/invitations/accept 엔드포인트를 permitAll()에서 제외 (인증 필요 경로로 변경)
- 초대 수락 후 리다이렉트: 백엔드 URL → 프론트엔드 URL로 변경
- 이메일 일치 여부와 관계없이 초대 수락 허용하도록 완화
- docs/invitation-flow.md 초대 플로우 스펙 문서 추가

<br>

## 테스트 및 검증 내용

- 소셜 로그인 완료 후 state 파라미터에서 초대 토큰 복원 및 자동 수락 동작 확인
- PENDING 멤버가 멤버 목록에서 제외됨을 확인
- 잘못된 이메일 형식으로 초대 요청 시 400 응답 반환 확인
- 초대 수락 후 프론트엔드 URL로 정상 리다이렉트 확인

<br>

## 🤔 주요 고민과 해결 과정

**[쿠키 → OAuth state 파라미터 전환]**

쿠키 방식은 소셜 로그인 OAuth 리다이렉트 과정에서 쿠키가 유실되는 문제가 있었습니다.
OAuth2 표준의 state 파라미터는 인증 요청부터 콜백까지 상태를 안전하게 전달하는 용도로 설계되어 있어,
초대 토큰을 인코딩하여 포함시키는 방식으로 전환했습니다.
