### PR TITLE
AI 피드백 및 초안 생성 프롬프트 수정 - 답변 짤리는 문제 해결

### DIFF
--- a/src/main/java/com/aidea/aidea/domain/aifeedback/service/GeminiService.java
+++ b/src/main/java/com/aidea/aidea/domain/aifeedback/service/GeminiService.java
@@ -6,6 +6,7 @@ import com.aidea.aidea.domain.aifeedback.entity.FeedbackStatus;
 import com.aidea.aidea.domain.aifeedback.entity.Question;
 import com.aidea.aidea.domain.aifeedback.repository.FeedbackRepository;
 import com.aidea.aidea.domain.aifeedback.service.dto.GeminiResult;
+import com.aidea.aidea.domain.documents.entity.DocumentType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -42,13 +43,19 @@ public class GeminiService {
     @Value("${gemini.model}")
     private String geminiModel;
 
-    private final RestClient restClient = RestClient.builder()
-            .requestFactory(new JdkClientHttpRequestFactory(
-                    HttpClient.newBuilder()
-                            .connectTimeout(Duration.ofSeconds(10))
-                            .build()
-            ))
-            .build();
+    private final RestClient restClient = createRestClient();
+
+    private static RestClient createRestClient() {
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(
+                HttpClient.newBuilder()
+                        .connectTimeout(Duration.ofSeconds(10))
+                        .build()
+        );
+        requestFactory.setReadTimeout(Duration.ofSeconds(120));
+        return RestClient.builder()
+                .requestFactory(requestFactory)
+                .build();
+    }
 
     @Async
     @Transactional
@@ -63,11 +70,13 @@ public class GeminiService {
             String prompt = buildInitialPrompt(
                     feedback.getOriginalMarkdown(),
                     feedback.getAdditionalRequest(),
-                    feedback.getIdeaMarkdown()
+                    feedback.getIdeaMarkdown(),
+                    feedback.getDocument().getType()
             );
             log.info("[Gemini] 프롬프트 생성 완료 feedbackId={} promptLength={}", feedbackId, prompt.length());
 
-            GeminiResult result = callGeminiApi(prompt);
+            // 1차 호출은 "충분한지/빈약한지" 판단이 필요하므로 추론 예산을 부여
+            GeminiResult result = callGeminiApi(prompt, THINKING_BUDGET_JUDGMENT);
             log.info("[Gemini] API 응답 수신 feedbackId={} resultType={}", feedbackId, result.type());
 
             if (result.type() == GeminiResult.Type.QUESTIONS) {
@@ -97,11 +106,13 @@ public class GeminiService {
                     feedback.getQuestions(),
                     feedback.getAnswers(),
                     feedback.getAdditionalRequest(),
-                    feedback.getIdeaMarkdown()
+                    feedback.getIdeaMarkdown(),
+                    feedback.getDocument().getType()
             );
             log.info("[Gemini] 프롬프트 생성 완료 feedbackId={} promptLength={}", feedbackId, prompt.length());
 
-            GeminiResult result = callGeminiApi(prompt);
+            // 이미 type=FEEDBACK으로 방향이 정해진 단순 생성 호출이므로 추론 불필요
+            GeminiResult result = callGeminiApi(prompt, THINKING_BUDGET_SIMPLE);
             log.info("[Gemini] API 응답 수신 feedbackId={} resultType={}", feedbackId, result.type());
 
             if (result.type() != GeminiResult.Type.FEEDBACK) {
@@ -159,7 +170,12 @@ public class GeminiService {
     }
 
 
-    private GeminiResult callGeminiApi(String prompt) throws Exception {
+    // 판단(QUESTIONS/FEEDBACK 분기)이 필요한 호출에 부여하는 추론 예산
+    private static final int THINKING_BUDGET_JUDGMENT = 2048;
+    // 방향이 이미 정해진 단순 생성 호출은 추론을 끔
+    private static final int THINKING_BUDGET_SIMPLE = 0;
+
+    private GeminiResult callGeminiApi(String prompt, int thinkingBudget) throws Exception {
         Map<String, Object> requestBody = Map.of(
                 "contents", List.of(
                         Map.of("parts", List.of(Map.of("text", prompt)))
@@ -167,8 +183,8 @@ public class GeminiService {
                 "generationConfig", Map.of(
                         "responseMimeType", "application/json",
                         "responseSchema", buildResponseSchema(),
-                        "thinkingConfig", Map.of("thinkingBudget", 0),
-                        "maxOutputTokens", 8192
+                        "thinkingConfig", Map.of("thinkingBudget", thinkingBudget),
+                        "maxOutputTokens", 65536
                 )
         );
 
@@ -241,9 +257,12 @@ public class GeminiService {
                                                 "text", Map.of("type", "STRING"),
                                                 "options", Map.of(
                                                         "type", "ARRAY",
-                                                        "items", Map.of("type", "STRING")
+                                                        "items", Map.of("type", "STRING"),
+                                                        "minItems", 3,
+                                                        "maxItems", 5
                                                 )
-                                        )
+                                        ),
+                                        "required", List.of("id", "section", "text", "options")
                                 )
                         )
                 ),
@@ -252,7 +271,7 @@ public class GeminiService {
     }
 
     //Gemini에게 줄 첫 명령서 작성
-    private String buildInitialPrompt(String originalMarkdown, String additionalRequest, String ideaMarkdown) {
+    private String buildInitialPrompt(String originalMarkdown, String additionalRequest, String ideaMarkdown, DocumentType documentType) {
         String ideaSection = (ideaMarkdown != null && !ideaMarkdown.isBlank())
                 ? "[IDEA DOCUMENT]\n" + ideaMarkdown + "\n\n"
                 : "";
@@ -265,6 +284,8 @@ public class GeminiService {
             - 문서가 충분히 구체적이면 → 수정안을 작성
             - 문서가 너무 빈약하면 → 핵심 정보를 묻는 질문 생성
 
+            이 문서는 %s야. 이런 문서가 반드시 다뤄야 할 핵심 항목은 다음과 같아: %s
+
             %s[DOCUMENT]
             %s
 
@@ -274,18 +295,22 @@ public class GeminiService {
             [INSTRUCTION]
             1. 문서의 정보량과 구체성을 판단해.
             2. [IDEA DOCUMENT]가 있으면 해당 아이디어의 방향성과 맥락을 참고해서 검토해.
-            3. 빈약 판단 기준:
-               - 핵심 기능, 타깃 사용자, 차별점 중 2개 이상이 한 줄 미만이거나 없음
-               - 또는 전체 문서가 200자 미만
+            3. 빈약 판단 기준: 위 핵심 항목 중 2개 이상이 한 줄 미만이거나 없음, 또는 전체 문서가 200자 미만
             4. 충분 판단이면 type="FEEDBACK", revisedMarkdown에 개선된 마크다운 작성
-               (원본 구조 유지, 부족한 섹션 보강, 모호한 표현 명확화)
-            5. 빈약 판단이면 type="QUESTIONS", questions에 핵심 정보를 묻는 질문 3~5개 생성
-               각 질문은 id(q1, q2 ...), section(어느 섹션인지), text(질문 내용),
-               options(객관식 선택지, 가능하면) 포함
+               - 원본 구조는 유지하면서, 위 핵심 항목 중 빠지거나 부실한 부분을 보강해
+               - "다양한 기능", "편리한 UI"처럼 모호한 표현은 구체적인 값으로 바꿔 써
+               - 분량은 섹션별로 원본 대비 최대 1.5배 이내로 — 과도하게 늘리지 말고 핵심만 보강
+            5. 빈약 판단이면 type="QUESTIONS", questions에 핵심 정보를 묻는 질문 3~5개 생성.
+               각 질문은 id(q1, q2 ...), section(어느 섹션인지), text(질문 내용)와 함께
+               options에 서로 구분되는 구체적인 보기를 3~4개 반드시 포함해.
+               자유 서술형(주관식) 질문은 만들지 마라 — 사용자가 그 중 하나를 고르거나
+               직접 입력할 수 있도록, 보기는 실제로 선택 가능한 구체적인 값으로 작성해.
 
             [OUTPUT]
             반드시 JSON 형식. 다른 형식 절대 안 됨.
             """.formatted(
+                documentType.displayName(),
+                documentType.requiredElements(),
                 ideaSection,
                 originalMarkdown,
                 additionalRequest != null ? additionalRequest : "없음"
@@ -298,7 +323,8 @@ public class GeminiService {
             List<Question> questions,
             List<Answer> answers,
             String additionalRequest,
-            String ideaMarkdown
+            String ideaMarkdown,
+            DocumentType documentType
     ) {
         String ideaSection = (ideaMarkdown != null && !ideaMarkdown.isBlank())
                 ? "[IDEA DOCUMENT]\n" + ideaMarkdown + "\n\n"
@@ -323,6 +349,8 @@ public class GeminiService {
             이전에 사용자에게 핵심 정보를 묻는 질문을 했고, 답변을 받았어.
             이제 원본 + 답변을 합쳐서 수정안을 작성해.
 
+            이 문서는 %s야. 이런 문서가 반드시 다뤄야 할 핵심 항목은 다음과 같아: %s
+
             %s[ORIGINAL DOCUMENT]
             %s
 
@@ -334,13 +362,16 @@ public class GeminiService {
 
             [INSTRUCTION]
             - [IDEA DOCUMENT]가 있으면 아이디어의 방향성을 참고해서 수정안 작성
-            - 답변 정보를 원본에 자연스럽게 녹여서 수정안 작성
+            - 답변 정보를 원본과 위 핵심 항목에 자연스럽게 녹여서 수정안 작성
             - 사용자가 답하지 않은 영역은 추측하지 말고 기존 내용 유지
+            - 분량은 섹션별로 원본 대비 최대 1.5배 이내로 — 과도하게 늘리지 말고 핵심만 보강
             - type="FEEDBACK"으로 응답, revisedMarkdown에 마크다운
 
             [OUTPUT]
             반드시 JSON 형식.
             """.formatted(
+                documentType.displayName(),
+                documentType.requiredElements(),
                 ideaSection,
                 originalMarkdown,
                 qa.toString(),

--- a/src/main/java/com/aidea/aidea/domain/documents/dto/ActiveDraftInfo.java
+++ b/src/main/java/com/aidea/aidea/domain/documents/dto/ActiveDraftInfo.java
@@ -1,9 +1,13 @@
 package com.aidea.aidea.domain.documents.dto;
 
+import com.aidea.aidea.domain.draft.entity.DraftQuestion;
 import com.aidea.aidea.domain.draft.entity.DraftStatus;
+
+import java.util.List;
 
 public record ActiveDraftInfo(
         String draftId,
         DraftStatus status,
-        String content
+        String content,
+        List<DraftQuestion> questions
 ) {}

--- a/src/main/java/com/aidea/aidea/domain/documents/entity/DocumentType.java
+++ b/src/main/java/com/aidea/aidea/domain/documents/entity/DocumentType.java
@@ -5,5 +5,27 @@ public enum DocumentType {
     PLAN,
     USER_SCENARIO,
     API_SPEC,
-    ERD
+    ERD;
+
+    // AI 프롬프트에 주입할 문서 종류 한글 명칭
+    public String displayName() {
+        return switch (this) {
+            case IDEA -> "서비스 아이디어 기획서";
+            case PLAN -> "프로젝트 계획서";
+            case USER_SCENARIO -> "유저 시나리오 문서";
+            case API_SPEC -> "REST API 명세서";
+            case ERD -> "ERD 설명 문서";
+        };
+    }
+
+    // AI 프롬프트에 "이 문서가 반드시 다뤄야 할 핵심 항목"으로 주입할 목록
+    public String requiredElements() {
+        return switch (this) {
+            case IDEA -> "핵심 가치(어떤 문제를 해결하는지), 타깃 사용자, 핵심 기능, 경쟁 서비스 대비 차별점";
+            case PLAN -> "프로젝트 목표, 주요 기능 목록, 개발 단계(마일스톤)별 범위, 예상 일정";
+            case USER_SCENARIO -> "주요 사용자 유형, Use Case별 진행 흐름(최소 3개), 예외/대안 흐름";
+            case API_SPEC -> "주요 엔드포인트(HTTP 메서드+경로), 요청/응답 필드와 타입, 인증·에러 처리 방식";
+            case ERD -> "주요 엔티티 목록, 엔티티별 핵심 필드와 타입, 엔티티 간 관계(1:N, N:M 등)";
+        };
+    }
 }

--- a/src/main/java/com/aidea/aidea/domain/documents/websocket/DocumentWebSocketHandler.java
+++ b/src/main/java/com/aidea/aidea/domain/documents/websocket/DocumentWebSocketHandler.java
@@ -7,6 +7,7 @@ import com.aidea.aidea.domain.draft.service.DraftEventPublisher;
 import com.aidea.aidea.domain.documents.dto.ActiveDraftInfo;
 import com.aidea.aidea.domain.documents.dto.ActiveFeedbackInfo;
 import com.aidea.aidea.domain.documents.service.DocumentService;
+import com.aidea.aidea.domain.draft.entity.DraftStatus;
 import com.aidea.aidea.domain.draft.repository.DraftRepository;
 import com.aidea.aidea.domain.teamspace.entity.MemberRole;
 import com.aidea.aidea.global.websocket.SocketErrorCode;
@@ -156,7 +157,12 @@ public class DocumentWebSocketHandler extends TextWebSocketHandler implements Fe
                 activeFeedback != null ? activeFeedback.status() : "none");
 
         ActiveDraftInfo activeDraft = draftRepository.findByDocumentId(docId)
-                .map(d -> new ActiveDraftInfo(d.getId(), d.getStatus(), d.getContent()))
+                .map(d -> new ActiveDraftInfo(
+                        d.getId(),
+                        d.getStatus(),
+                        d.getContent(),
+                        d.getStatus() == DraftStatus.QUESTIONING ? d.getQuestions() : null
+                ))
                 .orElse(null);
 
         Map<String, Object> event = new LinkedHashMap<>();

--- a/src/main/java/com/aidea/aidea/domain/draft/controller/DraftController.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/controller/DraftController.java
@@ -1,0 +1,42 @@
+package com.aidea.aidea.domain.draft.controller;
+
+import com.aidea.aidea.domain.draft.controller.dto.DraftAnswerRequest;
+import com.aidea.aidea.domain.draft.controller.dto.DraftAnswerResponse;
+import com.aidea.aidea.domain.draft.service.DraftService;
+import com.aidea.aidea.global.dto.GlobalResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Draft")
+@RestController
+@RequestMapping("/api/drafts")
+@RequiredArgsConstructor
+public class DraftController {
+
+    private final DraftService draftService;
+
+    @Operation(summary = "IDEA 초안 구체화 질문에 대한 답변 제출 (비워서 보내면 건너뛰기)")
+    @PostMapping("/{draftId}/answers")
+    public ResponseEntity<GlobalResponse<DraftAnswerResponse>> submitAnswer(
+            @PathVariable String draftId,
+            @Valid @RequestBody DraftAnswerRequest request,
+            @AuthenticationPrincipal String userIdStr) {
+
+        Long userId = Long.parseLong(userIdStr);
+        DraftAnswerResponse response = draftService.submitDraftAnswer(draftId, request, userId);
+
+        return ResponseEntity
+                .status(HttpStatus.ACCEPTED)
+                .body(GlobalResponse.ok("답변을 처리하고 있습니다.", response));
+    }
+}

--- a/src/main/java/com/aidea/aidea/domain/draft/controller/dto/DraftAnswerRequest.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/controller/dto/DraftAnswerRequest.java
@@ -1,0 +1,23 @@
+package com.aidea.aidea.domain.draft.controller.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+// 질문에 대한 답변 제출 요청. answer를 비워서 보내면 "건너뛰기"로 처리되어
+// 원본 아이디어 설명만으로 바로 최종 초안 생성으로 진행한다.
+public record DraftAnswerRequest(
+
+    @Valid
+    List<AnswerItem> answer
+) {
+    public record AnswerItem(
+
+            @NotBlank(message = "questionId는 필수입니다")
+            String questionId,
+
+            @NotBlank(message = "answer 값은 필수입니다")
+            String value
+    ) {}
+}

--- a/src/main/java/com/aidea/aidea/domain/draft/controller/dto/DraftAnswerResponse.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/controller/dto/DraftAnswerResponse.java
@@ -1,0 +1,13 @@
+package com.aidea.aidea.domain.draft.controller.dto;
+
+import com.aidea.aidea.domain.draft.entity.Draft;
+import com.aidea.aidea.domain.draft.entity.DraftStatus;
+
+public record DraftAnswerResponse(
+        String draftId,
+        DraftStatus status
+) {
+    public static DraftAnswerResponse from(Draft draft) {
+        return new DraftAnswerResponse(draft.getId(), draft.getStatus());
+    }
+}

--- a/src/main/java/com/aidea/aidea/domain/draft/converter/DraftAnswersConverter.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/converter/DraftAnswersConverter.java
@@ -1,0 +1,36 @@
+package com.aidea.aidea.domain.draft.converter;
+
+import com.aidea.aidea.domain.draft.entity.DraftAnswer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.List;
+
+@Converter
+public class DraftAnswersConverter implements AttributeConverter<List<DraftAnswer>, String> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<DraftAnswer> answers) {
+        if (answers == null) return null;
+        try {
+            return OBJECT_MAPPER.writeValueAsString(answers);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("DraftAnswer 직렬화 실패", e);
+        }
+    }
+
+    @Override
+    public List<DraftAnswer> convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        try {
+            return OBJECT_MAPPER.readValue(dbData, new TypeReference<List<DraftAnswer>>() {});
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("DraftAnswer 역직렬화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/aidea/aidea/domain/draft/converter/DraftQuestionsConverter.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/converter/DraftQuestionsConverter.java
@@ -1,0 +1,36 @@
+package com.aidea.aidea.domain.draft.converter;
+
+import com.aidea.aidea.domain.draft.entity.DraftQuestion;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.List;
+
+@Converter
+public class DraftQuestionsConverter implements AttributeConverter<List<DraftQuestion>, String> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<DraftQuestion> questions) {
+        if (questions == null) return null;
+        try {
+            return OBJECT_MAPPER.writeValueAsString(questions);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("DraftQuestion 직렬화 실패", e);
+        }
+    }
+
+    @Override
+    public List<DraftQuestion> convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        try {
+            return OBJECT_MAPPER.readValue(dbData, new TypeReference<List<DraftQuestion>>() {});
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("DraftQuestion 역직렬화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/aidea/aidea/domain/draft/entity/Draft.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/entity/Draft.java
@@ -1,6 +1,8 @@
 package com.aidea.aidea.domain.draft.entity;
 
 import com.aidea.aidea.domain.documents.entity.Document;
+import com.aidea.aidea.domain.draft.converter.DraftAnswersConverter;
+import com.aidea.aidea.domain.draft.converter.DraftQuestionsConverter;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -8,6 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "drafts")
@@ -40,6 +43,16 @@ public class Draft {
 
     @Column(name = "idea_context", columnDefinition = "MEDIUMTEXT")
     private String ideaContext;
+
+    @Setter
+    @Column(name = "questions", columnDefinition = "JSON")
+    @Convert(converter = DraftQuestionsConverter.class)
+    private List<DraftQuestion> questions;
+
+    @Setter
+    @Column(name = "answers", columnDefinition = "JSON")
+    @Convert(converter = DraftAnswersConverter.class)
+    private List<DraftAnswer> answers;
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;

--- a/src/main/java/com/aidea/aidea/domain/draft/entity/DraftAnswer.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/entity/DraftAnswer.java
@@ -1,0 +1,7 @@
+package com.aidea.aidea.domain.draft.entity;
+
+// 사용자가 제출하는 IDEA 구체화 질문에 대한 답변 한 개
+public record DraftAnswer(
+        String questionId, // DraftQuestion.id 참조
+        String value       // 선택했거나 직접 입력한 답변
+) {}

--- a/src/main/java/com/aidea/aidea/domain/draft/entity/DraftQuestion.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/entity/DraftQuestion.java
@@ -1,0 +1,11 @@
+package com.aidea.aidea.domain.draft.entity;
+
+import java.util.List;
+
+// IDEA 초안을 구체화하기 위해 Gemini가 생성하는 질문 한 개 (항상 객관식 보기를 포함)
+public record DraftQuestion(
+        String id,
+        String section,
+        String text,
+        List<String> options
+) {}

--- a/src/main/java/com/aidea/aidea/domain/draft/entity/DraftStatus.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/entity/DraftStatus.java
@@ -1,7 +1,9 @@
 package com.aidea.aidea.domain.draft.entity;
 
 public enum DraftStatus {
-    PENDING,  // Gemini 호출 중
-    DONE,     // 초안 생성 완료
-    FAILED    // 실패
+    PENDING,      // Gemini 호출 중 (또는 IDEA 완료 대기 중)
+    QUESTIONING,  // (IDEA 전용) 질문 생성 완료, 사용자 답변 대기
+    ANSWERING,    // (IDEA 전용) 답변 받음, 최종 초안 생성 중
+    DONE,         // 초안 생성 완료
+    FAILED        // 실패
 }

--- a/src/main/java/com/aidea/aidea/domain/draft/service/DraftAsyncExecutor.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/service/DraftAsyncExecutor.java
@@ -3,6 +3,8 @@ package com.aidea.aidea.domain.draft.service;
 import com.aidea.aidea.domain.documents.entity.Document;
 import com.aidea.aidea.domain.documents.entity.DocumentAiStatus;
 import com.aidea.aidea.domain.draft.entity.Draft;
+import com.aidea.aidea.domain.draft.entity.DraftAnswer;
+import com.aidea.aidea.domain.draft.entity.DraftQuestion;
 import com.aidea.aidea.domain.draft.entity.DraftStatus;
 import com.aidea.aidea.domain.draft.repository.DraftRepository;
 import com.aidea.aidea.domain.teamspace.service.TeamspaceEventPublisher;
@@ -30,6 +32,7 @@ import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 @Component
 @RequiredArgsConstructor
@@ -49,26 +52,70 @@ public class DraftAsyncExecutor {
     @Value("${gemini.base-url}") private String geminiBaseUrl;
     @Value("${gemini.model}")    private String geminiModel;
 
-    private final RestClient restClient = RestClient.builder()
-            .requestFactory(new JdkClientHttpRequestFactory(
-                    HttpClient.newBuilder()
-                            .connectTimeout(Duration.ofSeconds(10))
-                            .build()))
-            .build();
+    private final RestClient restClient = createRestClient();
 
+    private static RestClient createRestClient() {
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(
+                HttpClient.newBuilder()
+                        .connectTimeout(Duration.ofSeconds(10))
+                        .build()
+        );
+        requestFactory.setReadTimeout(Duration.ofSeconds(120));
+        return RestClient.builder()
+                .requestFactory(requestFactory)
+                .build();
+    }
+
+    /**
+     * IDEA 문서 초안 생성의 진입점.
+     * 짧은 아이디어 설명만으로 바로 초안을 쓰는 대신, 먼저 아이디어를 구체화하기 위한
+     * 객관식 질문을 생성해 QUESTIONING으로 전환한다 (질문 → 답변 → 최종 생성의 2단계 흐름).
+     * 이 메서드는 IDEA 문서에 대해서만 호출된다 — PLAN 등 나머지 문서는
+     * generateDraftAsync(draftId, teamspaceId, teamspaceName, ideaContentOverride)로 단일 호출 생성된다.
+     */
     @Async
     @Transactional
     public void generateDraftAsync(String draftId, String teamspaceId, String teamspaceName) {
-        log.warn("[DRAFT] generateDraftAsync started draftId={} teamspaceId={} thread={}", draftId, teamspaceId, Thread.currentThread().getName());
+        log.warn("[DRAFT] generateDraftAsync (IDEA questions) started draftId={} teamspaceId={} thread={}", draftId, teamspaceId, Thread.currentThread().getName());
 
         Draft draft = draftRepository.findById(draftId)
                 .orElseThrow(() -> new IllegalStateException("draft not found: " + draftId));
         Document document = draft.getDocument();
 
         try {
-            log.warn("[DRAFT] calling Gemini draftId={} docType={} apiKeyPrefix={}", draftId, document.getType(),
+            log.warn("[DRAFT] calling Gemini for IDEA questions draftId={} apiKeyPrefix={}", draftId,
                 apiKey != null && apiKey.length() > 8 ? apiKey.substring(0, 8) + "..." : "(empty)");
-            String prompt = buildPrompt(document.getType(), draft.getIdeaContext(), teamspaceName);
+            String prompt = buildIdeaQuestionPrompt(draft.getIdeaContext(), teamspaceName);
+            List<DraftQuestion> questions = callGeminiQuestionsApi(prompt);
+
+            draft.setQuestions(questions);
+            draft.setStatus(DraftStatus.QUESTIONING);
+            log.warn("[DRAFT] QUESTIONING 상태 전환 draftId={} questionCount={}", draftId, questions.size());
+
+            teamspaceEventPublisher.publishDraftQuestioning(teamspaceId, document.getId(), draft.getId(), questions);
+
+        } catch (Exception e) {
+            handleDraftFailure(draft, document, teamspaceId, e);
+        }
+    }
+
+    /**
+     * IDEA 질문에 대한 답변(또는 빈 답변 — 건너뛰기) 제출 후 호출되는 최종 생성 단계.
+     * 원본 아이디어 설명에 Q&A로 확보한 정보를 더해 최종 IDEA 초안을 생성하고,
+     * 완료되면 기존과 동일하게 draft:ready/draft:applied를 발행하고 나머지 문서 초안을 트리거한다.
+     */
+    @Async
+    @Transactional
+    public void generateFinalIdeaDraft(String draftId, String teamspaceId, String teamspaceName) {
+        log.warn("[DRAFT] generateFinalIdeaDraft started draftId={} teamspaceId={} thread={}", draftId, teamspaceId, Thread.currentThread().getName());
+
+        Draft draft = draftRepository.findById(draftId)
+                .orElseThrow(() -> new IllegalStateException("draft not found: " + draftId));
+        Document document = draft.getDocument();
+
+        try {
+            String enrichedContext = mergeIdeaContextWithAnswers(draft.getIdeaContext(), draft.getQuestions(), draft.getAnswers());
+            String prompt = buildPrompt(document.getType(), enrichedContext, teamspaceName);
             String content = callGeminiApi(prompt);
 
             draft.setContent(content);
@@ -77,18 +124,16 @@ public class DraftAsyncExecutor {
 
             teamspaceEventPublisher.publishDraftReady(teamspaceId, document.getId(), draft.getId(), content);
             publishDraftAppliedToDocument(document.getId(), draft.getId(), content);
-            log.warn("[DRAFT] generation complete draftId={}", draftId);
+            log.warn("[DRAFT] IDEA final generation complete draftId={}", draftId);
 
-            if (document.getType() == com.aidea.aidea.domain.documents.entity.DocumentType.IDEA) {
-                final String ideaContent = content;
-                TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                    @Override
-                    public void afterCommit() {
-                        log.warn("[DRAFT] IDEA done - triggering pending drafts teamspaceId={}", teamspaceId);
-                        triggerPendingDraftsWithIdeaContent(teamspaceId, teamspaceName, ideaContent);
-                    }
-                });
-            }
+            final String ideaContent = content;
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    log.warn("[DRAFT] IDEA done - triggering pending drafts teamspaceId={}", teamspaceId);
+                    triggerPendingDraftsWithIdeaContent(teamspaceId, teamspaceName, ideaContent);
+                }
+            });
 
         } catch (Exception e) {
             handleDraftFailure(draft, document, teamspaceId, e);
@@ -212,13 +257,7 @@ public class DraftAsyncExecutor {
 
     private String buildPrompt(com.aidea.aidea.domain.documents.entity.DocumentType type,
                                 String ideaContext, String teamspaceName) {
-        String typeInstruction = switch (type) {
-            case IDEA          -> "서비스 아이디어 기획서 (핵심 가치, 타깃 사용자, 차별점 포함)";
-            case PLAN          -> "프로젝트 계획서 (목표, 주요 기능, 개발 단계, 예상 일정 포함)";
-            case USER_SCENARIO -> "유저 시나리오 문서 (주요 사용자 유형, Use Case 3~5개 포함)";
-            case API_SPEC      -> "REST API 명세서 (주요 엔드포인트, 요청/응답 형식 포함)";
-            case ERD           -> "ERD 설명 문서 (주요 엔티티, 핵심 필드, 관계 포함)";
-        };
+        String typeInstruction = type.displayName() + " (" + type.requiredElements() + " 포함)";
 
         String projectSection = (teamspaceName != null && !teamspaceName.isBlank())
                 ? "[PROJECT NAME]\n" + teamspaceName + "\n\n"
@@ -234,8 +273,8 @@ public class DraftAsyncExecutor {
             %s%s[INSTRUCTION]
             - 실제로 채워야 할 내용은 [TODO: 구체적으로 무엇을 써야 하는지] 형태로 표시
             - 이미 알 수 있는 내용(문서 제목, 기본 구조, 아이디어에서 유추 가능한 내용)은 직접 작성
-            - 섹션 제목은 구체적으로 작성
-            - 전체 길이 1000자
+            - 위에서 언급한 핵심 항목을 각각 별도 섹션으로 구성하고, 섹션 제목은 구체적으로 작성
+            - 각 섹션은 200~400자 내외로 작성 (TODO로 표시만 하는 부분은 분량 제한에서 제외)
             """.formatted(typeInstruction, projectSection, ideaSection);
     }
 
@@ -243,9 +282,17 @@ public class DraftAsyncExecutor {
     private static final long RETRY_DELAY_MS = 3_000L;
 
     private String callGeminiApi(String prompt) throws Exception {
+        return callWithRetry(() -> executeGeminiRequest(prompt));
+    }
+
+    private List<DraftQuestion> callGeminiQuestionsApi(String prompt) throws Exception {
+        return callWithRetry(() -> executeIdeaQuestionsRequest(prompt));
+    }
+
+    private <T> T callWithRetry(Callable<T> call) throws Exception {
         for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
             try {
-                return executeGeminiRequest(prompt);
+                return call.call();
             } catch (HttpClientErrorException e) {
                 throw e; // 4xx는 재시도 불가
             } catch (Exception e) {
@@ -276,7 +323,7 @@ public class DraftAsyncExecutor {
         Map<String, Object> requestBody = Map.of(
                 "contents", List.of(Map.of("parts", List.of(Map.of("text", prompt)))),
                 "generationConfig", Map.of(
-                        "maxOutputTokens", 4096
+                        "maxOutputTokens", 65536
                 )
         );
 
@@ -309,5 +356,139 @@ public class DraftAsyncExecutor {
                 .orElseThrow(() -> new GeminiInvalidResponseException("Gemini text 파트 없음"));
 
         return stripMarkdownFence(raw);
+    }
+
+    // IDEA 초안을 구체화하기 위한 질문 생성 프롬프트 (2단계의 "항상 객관식" 패턴 재사용)
+    private String buildIdeaQuestionPrompt(String ideaContext, String teamspaceName) {
+        String projectSection = (teamspaceName != null && !teamspaceName.isBlank())
+                ? "[PROJECT NAME]\n" + teamspaceName + "\n\n"
+                : "";
+
+        return """
+            [ROLE] 너는 IT 스타트업 기획 컨설턴트야.
+            [CONTEXT]
+            사용자가 새 팀 프로젝트의 아이디어를 짧게 설명했어.
+            이 설명만으로 바로 기획서 초안을 쓰기엔 정보가 부족할 수 있어서,
+            본격적으로 작성하기 전에 더 구체적인 정보를 끌어내는 질문을 먼저 만들려고 해.
+
+            %s[IDEA]
+            %s
+
+            [INSTRUCTION]
+            1. 이 아이디어를 구체화하는 데 꼭 필요한 핵심 정보(%s)를 중심으로 질문 3~5개를 만들어.
+            2. 각 질문은 id(q1, q2 ...), section(어떤 항목에 대한 질문인지), text(질문 내용)와 함께
+               options에 서로 구분되는 구체적인 보기를 3~4개 반드시 포함해.
+            3. 자유 서술형(주관식) 질문은 만들지 마라 — 사용자가 그 중 하나를 고르거나
+               직접 입력할 수 있도록, 보기는 실제로 선택 가능한 구체적인 값으로 작성해.
+
+            [OUTPUT]
+            반드시 JSON 형식. 다른 형식 절대 안 됨.
+            """.formatted(
+                    projectSection,
+                    ideaContext,
+                    com.aidea.aidea.domain.documents.entity.DocumentType.IDEA.requiredElements()
+            );
+    }
+
+    // 2단계에서 확립한 "options 필수 + minItems/maxItems" 스키마 패턴을 그대로 재사용
+    private Map<String, Object> buildIdeaQuestionResponseSchema() {
+        return Map.of(
+                "type", "OBJECT",
+                "properties", Map.of(
+                        "questions", Map.of(
+                                "type", "ARRAY",
+                                "items", Map.of(
+                                        "type", "OBJECT",
+                                        "properties", Map.of(
+                                                "id", Map.of("type", "STRING"),
+                                                "section", Map.of("type", "STRING"),
+                                                "text", Map.of("type", "STRING"),
+                                                "options", Map.of(
+                                                        "type", "ARRAY",
+                                                        "items", Map.of("type", "STRING"),
+                                                        "minItems", 3,
+                                                        "maxItems", 5
+                                                )
+                                        ),
+                                        "required", List.of("id", "section", "text", "options")
+                                ),
+                                "minItems", 3,
+                                "maxItems", 5
+                        )
+                ),
+                "required", List.of("questions")
+        );
+    }
+
+    private record IdeaQuestionsResult(List<DraftQuestion> questions) {}
+
+    private List<DraftQuestion> executeIdeaQuestionsRequest(String prompt) throws Exception {
+        Map<String, Object> requestBody = Map.of(
+                "contents", List.of(Map.of("parts", List.of(Map.of("text", prompt)))),
+                "generationConfig", Map.of(
+                        "responseMimeType", "application/json",
+                        "responseSchema", buildIdeaQuestionResponseSchema(),
+                        "thinkingConfig", Map.of("thinkingBudget", 1024),
+                        "maxOutputTokens", 65536
+                )
+        );
+
+        String url = geminiBaseUrl + "/models/" + geminiModel + ":generateContent";
+
+        Map response = restClient.post()
+                .uri(url)
+                .header("x-goog-api-key", apiKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(requestBody)
+                .retrieve()
+                .body(Map.class);
+
+        List<Map<String, Object>> candidates = (List<Map<String, Object>>) response.get("candidates");
+        if (candidates == null || candidates.isEmpty()) {
+            throw new GeminiInvalidResponseException("Gemini 빈 응답");
+        }
+
+        Map<String, Object> content = (Map<String, Object>) candidates.get(0).get("content");
+        if (content == null) throw new GeminiInvalidResponseException("Gemini content 필드 없음");
+
+        List<Map<String, Object>> parts = (List<Map<String, Object>>) content.get("parts");
+        if (parts == null || parts.isEmpty()) throw new GeminiInvalidResponseException("Gemini parts 필드 없음");
+
+        String resultJson = parts.stream()
+                .filter(p -> !Boolean.TRUE.equals(p.get("thought")))
+                .map(p -> (String) p.get("text"))
+                .filter(t -> t != null && !t.isBlank())
+                .findFirst()
+                .orElseThrow(() -> new GeminiInvalidResponseException("Gemini text 파트 없음"));
+
+        IdeaQuestionsResult result = objectMapper.readValue(resultJson, IdeaQuestionsResult.class);
+        if (result.questions() == null || result.questions().isEmpty()) {
+            throw new GeminiInvalidResponseException("Gemini가 질문을 생성하지 않음");
+        }
+        return result.questions();
+    }
+
+    // 사용자가 답변을 제출했다면 원본 아이디어 설명에 Q&A 내용을 더해 최종 생성 프롬프트의 컨텍스트로 사용
+    // (답변을 건너뛴 경우 원본 설명만으로 바로 진행 — 기존 buildPrompt를 그대로 재사용하기 위해
+    //  Q&A를 별도 인자로 받지 않고 [IDEA] 컨텍스트 문자열에 합쳐 넣는다)
+    private String mergeIdeaContextWithAnswers(String ideaContext, List<DraftQuestion> questions, List<DraftAnswer> answers) {
+        if (questions == null || answers == null || answers.isEmpty()) {
+            return ideaContext;
+        }
+
+        StringBuilder qa = new StringBuilder();
+        for (DraftQuestion q : questions) {
+            answers.stream()
+                    .filter(a -> a.questionId().equals(q.id()))
+                    .map(DraftAnswer::value)
+                    .filter(v -> v != null && !v.isBlank())
+                    .findFirst()
+                    .ifPresent(value -> qa.append("- ").append(q.text()).append(" → ").append(value).append("\n"));
+        }
+
+        if (qa.isEmpty()) {
+            return ideaContext;
+        }
+        return ideaContext + "\n\n[추가로 확인된 정보]\n" + qa;
     }
 }

--- a/src/main/java/com/aidea/aidea/domain/draft/service/DraftAsyncExecutor.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/service/DraftAsyncExecutor.java
@@ -92,7 +92,14 @@ public class DraftAsyncExecutor {
             draft.setStatus(DraftStatus.QUESTIONING);
             log.warn("[DRAFT] QUESTIONING 상태 전환 draftId={} questionCount={}", draftId, questions.size());
 
-            teamspaceEventPublisher.publishDraftQuestioning(teamspaceId, document.getId(), draft.getId(), questions);
+            String dId = draft.getId();
+            List<DraftQuestion> qs = questions;
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    teamspaceEventPublisher.publishDraftQuestioning(teamspaceId, document.getId(), dId, qs);
+                }
+            });
 
         } catch (Exception e) {
             handleDraftFailure(draft, document, teamspaceId, e);

--- a/src/main/java/com/aidea/aidea/domain/draft/service/DraftService.java
+++ b/src/main/java/com/aidea/aidea/domain/draft/service/DraftService.java
@@ -3,11 +3,16 @@ package com.aidea.aidea.domain.draft.service;
 import com.aidea.aidea.domain.documents.entity.Document;
 import com.aidea.aidea.domain.documents.entity.DocumentAiStatus;
 import com.aidea.aidea.domain.documents.repository.DocumentRepository;
+import com.aidea.aidea.domain.draft.controller.dto.DraftAnswerRequest;
+import com.aidea.aidea.domain.draft.controller.dto.DraftAnswerResponse;
 import com.aidea.aidea.domain.draft.entity.Draft;
+import com.aidea.aidea.domain.draft.entity.DraftAnswer;
 import com.aidea.aidea.domain.draft.entity.DraftStatus;
 import com.aidea.aidea.domain.draft.repository.DraftRepository;
+import com.aidea.aidea.domain.teamspace.entity.MemberRole;
 import com.aidea.aidea.global.exception.CustomException;
 import com.aidea.aidea.global.exception.ErrorCode;
+import com.aidea.aidea.global.util.TeamspaceRoleValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -25,6 +31,7 @@ public class DraftService {
     private final DraftRepository draftRepository;
     private final DocumentRepository documentRepository;
     private final DraftAsyncExecutor draftAsyncExecutor;
+    private final TeamspaceRoleValidator roleValidator;
 
     @Transactional
     public void savePendingDraft(String documentId, String ideaContext) {
@@ -70,5 +77,41 @@ public class DraftService {
             }
         });
         log.warn("[DRAFT] afterCommit synchronization registered draftId={}", draftId);
+    }
+
+    @Transactional
+    public DraftAnswerResponse submitDraftAnswer(String draftId, DraftAnswerRequest request, Long userId) {
+        Draft draft = draftRepository.findById(draftId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DRAFT_NOT_FOUND));
+
+        Document document = draft.getDocument();
+        String teamspaceId = document.getTeamspace().getTeamspaceId();
+        roleValidator.requireRole(teamspaceId, userId, MemberRole.OWNER, MemberRole.MEMBER);
+
+        if (draft.getStatus() != DraftStatus.QUESTIONING) {
+            throw new CustomException(ErrorCode.DRAFT_INVALID_STATUS);
+        }
+
+        // answer를 비워서 보내면 "건너뛰기" — Q&A 없이 원본 설명만으로 바로 최종 생성으로 진행
+        List<DraftAnswer> answers = (request.answer() == null) ? List.of()
+                : request.answer().stream()
+                        .map(item -> new DraftAnswer(item.questionId(), item.value()))
+                        .toList();
+
+        draft.setAnswers(answers);
+        draft.setStatus(DraftStatus.ANSWERING);
+        log.warn("[DRAFT] ANSWERING 전환 draftId={} answerCount={}", draftId, answers.size());
+
+        String dId = draft.getId();
+        String teamspaceName = document.getTeamspace().getName();
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                log.warn("[DRAFT] afterCommit fired - scheduling final IDEA generation draftId={}", dId);
+                draftAsyncExecutor.generateFinalIdeaDraft(dId, teamspaceId, teamspaceName);
+            }
+        });
+
+        return DraftAnswerResponse.from(draft);
     }
 }

--- a/src/main/java/com/aidea/aidea/domain/teamspace/service/TeamspaceEventPublisher.java
+++ b/src/main/java/com/aidea/aidea/domain/teamspace/service/TeamspaceEventPublisher.java
@@ -1,6 +1,11 @@
 package com.aidea.aidea.domain.teamspace.service;
 
+import com.aidea.aidea.domain.draft.entity.DraftQuestion;
+
+import java.util.List;
+
 public interface TeamspaceEventPublisher {
     void publishDraftReady(String teamspaceId, String documentId, String draftId, String content);
     void publishDraftError(String teamspaceId, String documentId, String errorCode);
+    void publishDraftQuestioning(String teamspaceId, String documentId, String draftId, List<DraftQuestion> questions);
 }

--- a/src/main/java/com/aidea/aidea/domain/teamspace/websocket/TeamspaceWebSocketHandler.java
+++ b/src/main/java/com/aidea/aidea/domain/teamspace/websocket/TeamspaceWebSocketHandler.java
@@ -181,6 +181,19 @@ public class TeamspaceWebSocketHandler extends TextWebSocketHandler
         publishEvent(teamspaceId, "draft:error", Map.of("documentId", documentId, "errorCode", errorCode));
     }
 
+    @Override
+    public void publishDraftQuestioning(String teamspaceId, String documentId, String draftId,
+                                         List<com.aidea.aidea.domain.draft.entity.DraftQuestion> questions) {
+        log.warn("[WS-TS] publishDraftQuestioning teamspaceId={} documentId={} draftId={} questionCount={}",
+                teamspaceId, documentId, draftId, questions.size());
+        Map<String, Object> data = Map.of(
+                "documentId", documentId,
+                "draftId", draftId,
+                "questions", questions
+        );
+        publishEvent(teamspaceId, "draft:questioning", data);
+    }
+
     private void publishEvent(String teamspaceId, String eventType, Map<String, Object> data) {
         Set<WebSocketSession> sessions = teamspaceSessions.getOrDefault(teamspaceId, Collections.emptySet());
         if (sessions.isEmpty()) {

--- a/src/main/java/com/aidea/aidea/global/exception/ErrorCode.java
+++ b/src/main/java/com/aidea/aidea/global/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     
     // ===== 초안 (Draft) =====
     DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "DRAFT_NOT_FOUND", "초안을 찾을 수 없습니다."),
+    DRAFT_INVALID_STATUS(HttpStatus.BAD_REQUEST, "DRAFT_INVALID_STATUS", "현재 상태에서는 해당 작업을 수행할 수 없습니다."),
     DRAFT_IN_PROGRESS(HttpStatus.CONFLICT, "DRAFT_IN_PROGRESS", "초안 생성 중에는 피드백을 요청할 수 없습니다."),
     DRAFT_ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "DRAFT_ALREADY_IN_PROGRESS", "이미 초안 생성 중입니다."),
     DRAFT_QUOTA_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "DRAFT_QUOTA_EXCEEDED", "AI API 요청 한도를 초과했습니다."),

--- a/src/main/resources/db/migration/V4__add_questions_and_answers_to_drafts.sql
+++ b/src/main/resources/db/migration/V4__add_questions_and_answers_to_drafts.sql
@@ -1,0 +1,3 @@
+ALTER TABLE drafts
+    ADD COLUMN questions JSON NULL AFTER idea_context,
+    ADD COLUMN answers   JSON NULL AFTER questions;

--- a/src/main/resources/db/migration/V5__add_questioning_answering_to_draft_status.sql
+++ b/src/main/resources/db/migration/V5__add_questioning_answering_to_draft_status.sql
@@ -1,0 +1,2 @@
+ALTER TABLE drafts
+    MODIFY COLUMN status VARCHAR(20);


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #90

<br>

## 📝 작업 내용

AI 초안 생성에 2단계 Q&A 플로우를 추가했습니다.
문서 내용이 충분하지 않을 때 AI가 질문을 통해 추가 정보를 수집한 후 초안을 생성합니다.

주요 변경 사항:
- DraftQuestion / DraftAnswer 엔티티 추가 (JSON 컬럼으로 마이그레이션)
- 초안 상태에 QUESTIONING 추가: drafts.status 컬럼 ENUM → VARCHAR(20) 변경 (V5 마이그레이션)
- 상태 전이: PENDING → QUESTIONING → ANSWERING → DONE
- 답변 제출 API: POST /api/drafts/{draftId}/answers
- draft:questioning WebSocket 이벤트 추가: 질문 목록을 팀스페이스 채널로 전파
- doc:init 응답에 질문 데이터 포함: 페이지 재접속 시 진행 중인 Q&A 상태 복원
- DocumentType.displayName / requiredElements 필드 추가: 문서 타입별 요소를 Gemini 프롬프트에 동적 주입
- RestClient 읽기 타임아웃 120초 설정, maxOutputTokens 65536 상향, thinkingBudget 동적 설정
- WebSocket 이벤트 발행을 @TransactionalEventListener(phase = AFTER_COMMIT)으로 변경: 트랜잭션 롤백 시 이벤트 발행 방지

<br>

## 테스트 및 검증 내용

- 문서 내용이 부족한 경우 draft:questioning 이벤트 수신 및 질문 목록 표시 확인
- POST /api/drafts/{draftId}/answers 호출 후 ANSWERING → DONE 상태 전이 확인
- 페이지 재접속 시 doc:init에서 진행 중인 Q&A 상태 복원 확인
- 트랜잭션 롤백 시 WebSocket 이벤트 미발행 확인

<br>

## 🤔 주요 고민과 해결 과정

**[ENUM → VARCHAR 마이그레이션]**

초기 drafts.status가 DB ENUM 타입으로 정의되어 있어 QUESTIONING 값 추가 시 스키마 변경이 필요했습니다.
ENUM은 상태 추가 시마다 마이그레이션이 발생하므로 VARCHAR(20)으로 전환해 유연성을 높였습니다.

**[AFTER_COMMIT 이벤트 발행]**

트랜잭션 내부에서 이벤트를 발행하면 롤백 시에도 WebSocket 이벤트가 이미 전송된 상태가 발생했습니다.
@TransactionalEventListener(phase = AFTER_COMMIT)을 사용해 커밋 성공 후에만 이벤트를 발행하도록 수정했습니다.

