### PR TITLE
팀스페이스 멤버 역할 변경 기능 추가

### DIFF
--- a/src/main/java/com/aidea/aidea/domain/documents/websocket/DocumentHandshakeInterceptor.java
+++ b/src/main/java/com/aidea/aidea/domain/documents/websocket/DocumentHandshakeInterceptor.java
@@ -70,6 +70,7 @@ public class DocumentHandshakeInterceptor implements HandshakeInterceptor {
         attributes.put("docId", docId);
         attributes.put("userId", userId.toString());
         attributes.put("role", member.get().getRole());
+        attributes.put("teamspaceId", doc.getTeamspace().getTeamspaceId());
 
         log.info("[WS] handshake accepted userId={} docId={} role={}", userId, docId, member.get().getRole());
         return true;

--- a/src/main/java/com/aidea/aidea/domain/documents/websocket/DocumentWebSocketHandler.java
+++ b/src/main/java/com/aidea/aidea/domain/documents/websocket/DocumentWebSocketHandler.java
@@ -10,6 +10,7 @@ import com.aidea.aidea.domain.documents.service.DocumentService;
 import com.aidea.aidea.domain.draft.entity.DraftStatus;
 import com.aidea.aidea.domain.draft.repository.DraftRepository;
 import com.aidea.aidea.domain.teamspace.entity.MemberRole;
+import com.aidea.aidea.global.websocket.MemberRoleChangeListener;
 import com.aidea.aidea.global.websocket.SocketErrorCode;
 import com.aidea.aidea.global.websocket.SocketErrorSender;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -37,7 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class DocumentWebSocketHandler extends TextWebSocketHandler implements FeedbackEventPublisher, DraftEventPublisher {
+public class DocumentWebSocketHandler extends TextWebSocketHandler implements FeedbackEventPublisher, DraftEventPublisher, MemberRoleChangeListener {
 
     private final ConcurrentHashMap<String, Set<WebSocketSession>> docSessions
             = new ConcurrentHashMap<>();
@@ -313,6 +314,21 @@ public class DocumentWebSocketHandler extends TextWebSocketHandler implements Fe
                     s.sendMessage(message);
                 } catch (IOException e) {
                     log.warn("[WS] publishDraftToDocument failed sessionId={} docId={}", s.getId(), documentId);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onMemberRoleChanged(String teamspaceId, Long userId, MemberRole newRole) {
+        String userIdStr = userId.toString();
+        for (Set<WebSocketSession> sessions : docSessions.values()) {
+            for (WebSocketSession s : sessions) {
+                Map<String, Object> attrs = s.getAttributes();
+                if (teamspaceId.equals(attrs.get("teamspaceId")) && userIdStr.equals(attrs.get("userId"))) {
+                    attrs.put("role", newRole);
+                    log.info("[WS] role cache updated sessionId={} docId={} userId={} newRole={}",
+                            s.getId(), attrs.get("docId"), userId, newRole);
                 }
             }
         }

--- a/src/main/java/com/aidea/aidea/domain/teamspace/controller/MemberController.java
+++ b/src/main/java/com/aidea/aidea/domain/teamspace/controller/MemberController.java
@@ -1,8 +1,10 @@
 package com.aidea.aidea.domain.teamspace.controller;
 
 import com.aidea.aidea.domain.teamspace.dto.MemberInfoResponse;
+import com.aidea.aidea.domain.teamspace.dto.MemberRoleUpdateRequest;
 import com.aidea.aidea.domain.teamspace.service.MemberService;
 import com.aidea.aidea.global.dto.GlobalResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -21,5 +23,14 @@ public class MemberController {
             @PathVariable String teamspaceId,
             @AuthenticationPrincipal String userId) {
         return GlobalResponse.ok(memberService.getMembers(teamspaceId, Long.parseLong(userId)));
+    }
+
+    @PatchMapping("/{teamspaceId}/members/{memberId}/role")
+    public GlobalResponse<MemberInfoResponse> changeMemberRole(
+            @PathVariable String teamspaceId,
+            @PathVariable Long memberId,
+            @Valid @RequestBody MemberRoleUpdateRequest request,
+            @AuthenticationPrincipal String userId) {
+        return GlobalResponse.ok(memberService.changeMemberRole(teamspaceId, memberId, request.role(), Long.parseLong(userId)));
     }
 }

--- a/src/main/java/com/aidea/aidea/domain/teamspace/dto/MemberRoleUpdateRequest.java
+++ b/src/main/java/com/aidea/aidea/domain/teamspace/dto/MemberRoleUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.aidea.aidea.domain.teamspace.dto;
+
+import com.aidea.aidea.domain.teamspace.entity.MemberRole;
+import jakarta.validation.constraints.NotNull;
+
+public record MemberRoleUpdateRequest(
+        @NotNull MemberRole role
+) {
+}

--- a/src/main/java/com/aidea/aidea/domain/teamspace/entity/TeamspaceMember.java
+++ b/src/main/java/com/aidea/aidea/domain/teamspace/entity/TeamspaceMember.java
@@ -24,4 +24,8 @@ public class TeamspaceMember {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private MemberRole role;
+
+    public void changeRole(MemberRole role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/com/aidea/aidea/domain/teamspace/repository/TeamspaceMemberRepository.java
+++ b/src/main/java/com/aidea/aidea/domain/teamspace/repository/TeamspaceMemberRepository.java
@@ -1,5 +1,6 @@
 package com.aidea.aidea.domain.teamspace.repository;
 
+import com.aidea.aidea.domain.teamspace.entity.MemberRole;
 import com.aidea.aidea.domain.teamspace.entity.TeamspaceMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,4 +12,5 @@ public interface TeamspaceMemberRepository extends JpaRepository<TeamspaceMember
     List<TeamspaceMember> findByUserId(Long userId);
     void deleteAllByTeamspaceId(String teamspaceId);
     List<TeamspaceMember> findByTeamspaceId(String teamspaceId);
+    long countByTeamspaceIdAndRole(String teamspaceId, MemberRole role);
 }

--- a/src/main/java/com/aidea/aidea/domain/teamspace/service/MemberService.java
+++ b/src/main/java/com/aidea/aidea/domain/teamspace/service/MemberService.java
@@ -11,6 +11,8 @@ import com.aidea.aidea.domain.teamspace.entity.TeamspaceMember;
 import com.aidea.aidea.domain.teamspace.repository.TeamspaceMemberRepository;
 import com.aidea.aidea.global.exception.CustomException;
 import com.aidea.aidea.global.exception.ErrorCode;
+import com.aidea.aidea.global.util.TeamspaceRoleValidator;
+import com.aidea.aidea.global.websocket.MemberRoleChangeListener;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +30,8 @@ public class MemberService {
     private final TeamspaceMemberRepository teamspaceMemberRepository;
     private final InvitationRepository invitationRepository;
     private final UserRepository userRepository;
+    private final TeamspaceRoleValidator roleValidator;
+    private final List<MemberRoleChangeListener> roleChangeListeners;
 
     @Transactional(readOnly = true)
     public List<MemberInfoResponse> getMembers(String teamspaceId, Long userId) {
@@ -101,12 +105,47 @@ public class MemberService {
         TeamspaceMember target = teamspaceMemberRepository.findByTeamspaceIdAndUserId(teamspaceId, memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_TEAMSPACE_MEMBER));
 
-        // OWNER는 추방 불가
-        if (target.getRole() == MemberRole.OWNER) {
-            throw new CustomException(ErrorCode.INSUFFICIENT_PERMISSION);
-        }
+        // 팀스페이스의 마지막 OWNER는 추방 불가
+        assertNotLastOwner(teamspaceId, target);
 
         teamspaceMemberRepository.delete(target);
+    }
+
+    @Transactional
+    public MemberInfoResponse changeMemberRole(String teamspaceId, Long targetUserId, MemberRole newRole, Long userId) {
+        // 호출자 OWNER 확인
+        roleValidator.requireRole(teamspaceId, userId, MemberRole.OWNER);
+
+        // 대상 멤버 조회
+        TeamspaceMember target = teamspaceMemberRepository.findByTeamspaceIdAndUserId(teamspaceId, targetUserId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_TEAMSPACE_MEMBER));
+
+        if (target.getRole() != newRole) {
+            // 마지막 OWNER는 강등 불가
+            assertNotLastOwner(teamspaceId, target);
+            target.changeRole(newRole);
+
+            for (MemberRoleChangeListener listener : roleChangeListeners) {
+                listener.onMemberRoleChanged(teamspaceId, targetUserId, newRole);
+            }
+        }
+
+        User user = userRepository.findById(targetUserId).orElse(null);
+        return MemberInfoResponse.builder()
+                .userId(target.getUserId())
+                .name(user != null ? user.getName() : null)
+                .email(user != null ? user.getEmail() : null)
+                .role(target.getRole().name())
+                .status("ACTIVE")
+                .profileImageUrl(user != null ? user.getProfileImageUrl() : null)
+                .build();
+    }
+
+    private void assertNotLastOwner(String teamspaceId, TeamspaceMember target) {
+        if (target.getRole() == MemberRole.OWNER
+                && teamspaceMemberRepository.countByTeamspaceIdAndRole(teamspaceId, MemberRole.OWNER) <= 1) {
+            throw new CustomException(ErrorCode.TEAMSPACE_LAST_OWNER);
+        }
     }
 
     @Transactional

--- a/src/main/java/com/aidea/aidea/domain/teamspace/websocket/TeamspaceWebSocketHandler.java
+++ b/src/main/java/com/aidea/aidea/domain/teamspace/websocket/TeamspaceWebSocketHandler.java
@@ -6,6 +6,7 @@ import com.aidea.aidea.domain.teamspace.entity.MemberRole;
 import com.aidea.aidea.domain.teamspace.entity.TeamSpace;
 import com.aidea.aidea.domain.teamspace.repository.TeamSpaceRepository;
 import com.aidea.aidea.domain.teamspace.service.TeamspaceEventPublisher;
+import com.aidea.aidea.global.websocket.MemberRoleChangeListener;
 import com.aidea.aidea.global.websocket.SocketErrorCode;
 import com.aidea.aidea.global.websocket.SocketErrorSender;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -28,7 +29,7 @@ import java.util.stream.Collectors;
 @Component
 @RequiredArgsConstructor
 public class TeamspaceWebSocketHandler extends TextWebSocketHandler
-        implements TeamspaceEventPublisher {
+        implements TeamspaceEventPublisher, MemberRoleChangeListener {
 
     private final ConcurrentHashMap<String, Set<WebSocketSession>> teamspaceSessions
             = new ConcurrentHashMap<>();
@@ -192,6 +193,21 @@ public class TeamspaceWebSocketHandler extends TextWebSocketHandler
                 "questions", questions
         );
         publishEvent(teamspaceId, "draft:questioning", data);
+    }
+
+    @Override
+    public void onMemberRoleChanged(String teamspaceId, Long userId, MemberRole newRole) {
+        Set<WebSocketSession> sessions = teamspaceSessions.getOrDefault(teamspaceId, Collections.emptySet());
+
+        // 대상 유저의 모든 탭(세션)에 캐시된 role 갱신
+        for (WebSocketSession s : sessions) {
+            if (userId.toString().equals(s.getAttributes().get("userId"))) {
+                s.getAttributes().put("role", newRole);
+            }
+        }
+
+        log.info("[WS-TS] member:role_changed teamspaceId={} userId={} newRole={}", teamspaceId, userId, newRole);
+        publishEvent(teamspaceId, "member:role_changed", Map.of("userId", userId, "role", newRole.name()));
     }
 
     private void publishEvent(String teamspaceId, String eventType, Map<String, Object> data) {

--- a/src/main/java/com/aidea/aidea/global/exception/ErrorCode.java
+++ b/src/main/java/com/aidea/aidea/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     NOT_TEAMSPACE_OWNER(HttpStatus.FORBIDDEN, "NOT_TEAMSPACE_OWNER", "팀스페이스 소유자만 가능합니다."),
     NOT_TEAMSPACE_MEMBER(HttpStatus.FORBIDDEN, "NOT_TEAMSPACE_MEMBER", "팀스페이스 소속이 아닙니다."),
     INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "INSUFFICIENT_PERMISSION", "권한이 없습니다."),
+    TEAMSPACE_LAST_OWNER(HttpStatus.CONFLICT, "TEAMSPACE_LAST_OWNER", "팀스페이스에는 최소 1명의 Owner가 있어야 합니다."),
 
     // ===== 문서 (Document) =====
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "DOCUMENT_NOT_FOUND", "문서를 찾을 수 없습니다."),

--- a/src/main/java/com/aidea/aidea/global/websocket/MemberRoleChangeListener.java
+++ b/src/main/java/com/aidea/aidea/global/websocket/MemberRoleChangeListener.java
@@ -1,0 +1,11 @@
+package com.aidea.aidea.global.websocket;
+
+import com.aidea.aidea.domain.teamspace.entity.MemberRole;
+
+/**
+ * 멤버 역할 변경 시 WebSocket 세션에 캐시된 role 정보를 갱신하고
+ * 필요 시 결과를 실시간으로 전파하기 위한 리스너.
+ */
+public interface MemberRoleChangeListener {
+    void onMemberRoleChanged(String teamspaceId, Long userId, MemberRole newRole);
+}

--- a/src/test/java/com/aidea/aidea/domain/documents/websocket/DocumentWebSocketHandlerTest.java
+++ b/src/test/java/com/aidea/aidea/domain/documents/websocket/DocumentWebSocketHandlerTest.java
@@ -1,0 +1,121 @@
+package com.aidea.aidea.domain.documents.websocket;
+
+import com.aidea.aidea.domain.aifeedback.repository.FeedbackRepository;
+import com.aidea.aidea.domain.documents.service.DocumentService;
+import com.aidea.aidea.domain.draft.repository.DraftRepository;
+import com.aidea.aidea.domain.teamspace.entity.MemberRole;
+import com.aidea.aidea.global.websocket.SocketErrorSender;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentWebSocketHandlerTest {
+
+    @Mock
+    private DocumentUpdateBuffer updateBuffer;
+    @Mock
+    private DocumentService documentService;
+    @Mock
+    private FeedbackRepository feedbackRepository;
+    @Mock
+    private DraftRepository draftRepository;
+    @Mock
+    private SocketErrorSender socketErrorSender;
+    @Mock
+    private AwarenessStore awarenessStore;
+
+    private DocumentWebSocketHandler handler;
+
+    private static final String TEAMSPACE_ID = "ts-1";
+    private static final String OTHER_TEAMSPACE_ID = "ts-2";
+
+    @BeforeEach
+    void setUp() {
+        handler = new DocumentWebSocketHandler(updateBuffer, documentService, feedbackRepository, draftRepository,
+                new ObjectMapper(), socketErrorSender, awarenessStore);
+    }
+
+    private WebSocketSession sessionWith(String docId, String teamspaceId, String userId, MemberRole role) {
+        WebSocketSession session = mock(WebSocketSession.class);
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("docId", docId);
+        attributes.put("teamspaceId", teamspaceId);
+        attributes.put("userId", userId);
+        attributes.put("role", role);
+        when(session.getAttributes()).thenReturn(attributes);
+        return session;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void registerSession(String docId, WebSocketSession session) throws Exception {
+        Field field = DocumentWebSocketHandler.class.getDeclaredField("docSessions");
+        field.setAccessible(true);
+        ConcurrentHashMap<String, Set<WebSocketSession>> sessions =
+                (ConcurrentHashMap<String, Set<WebSocketSession>>) field.get(handler);
+        sessions.computeIfAbsent(docId, k -> ConcurrentHashMap.newKeySet()).add(session);
+    }
+
+    @Test
+    void onMemberRoleChanged_updatesCachedRole_forSameTeamspaceAndUser() throws Exception {
+        WebSocketSession targetSession = sessionWith("doc-1", TEAMSPACE_ID, "2", MemberRole.VIEWER);
+        registerSession("doc-1", targetSession);
+
+        handler.onMemberRoleChanged(TEAMSPACE_ID, 2L, MemberRole.MEMBER);
+
+        assertThat(targetSession.getAttributes().get("role")).isEqualTo(MemberRole.MEMBER);
+    }
+
+    @Test
+    void onMemberRoleChanged_doesNotUpdateOtherUsersSessions() throws Exception {
+        WebSocketSession targetSession = sessionWith("doc-1", TEAMSPACE_ID, "2", MemberRole.VIEWER);
+        WebSocketSession otherUserSession = sessionWith("doc-1", TEAMSPACE_ID, "3", MemberRole.MEMBER);
+        registerSession("doc-1", targetSession);
+        registerSession("doc-1", otherUserSession);
+
+        handler.onMemberRoleChanged(TEAMSPACE_ID, 2L, MemberRole.MEMBER);
+
+        assertThat(targetSession.getAttributes().get("role")).isEqualTo(MemberRole.MEMBER);
+        assertThat(otherUserSession.getAttributes().get("role")).isEqualTo(MemberRole.MEMBER); // unaffected
+    }
+
+    @Test
+    void onMemberRoleChanged_doesNotUpdateSessionsFromOtherTeamspaces() throws Exception {
+        WebSocketSession sameTeamspaceSession = sessionWith("doc-1", TEAMSPACE_ID, "2", MemberRole.VIEWER);
+        WebSocketSession otherTeamspaceSession = sessionWith("doc-2", OTHER_TEAMSPACE_ID, "2", MemberRole.VIEWER);
+        registerSession("doc-1", sameTeamspaceSession);
+        registerSession("doc-2", otherTeamspaceSession);
+
+        handler.onMemberRoleChanged(TEAMSPACE_ID, 2L, MemberRole.MEMBER);
+
+        assertThat(sameTeamspaceSession.getAttributes().get("role")).isEqualTo(MemberRole.MEMBER);
+        assertThat(otherTeamspaceSession.getAttributes().get("role")).isEqualTo(MemberRole.VIEWER);
+    }
+
+    @Test
+    void onMemberRoleChanged_updatesAllDocSessions_forUserConnectedToMultipleDocuments() throws Exception {
+        WebSocketSession docASession = sessionWith("doc-A", TEAMSPACE_ID, "2", MemberRole.VIEWER);
+        WebSocketSession docBSession = sessionWith("doc-B", TEAMSPACE_ID, "2", MemberRole.VIEWER);
+        registerSession("doc-A", docASession);
+        registerSession("doc-B", docBSession);
+
+        handler.onMemberRoleChanged(TEAMSPACE_ID, 2L, MemberRole.MEMBER);
+
+        assertThat(docASession.getAttributes().get("role")).isEqualTo(MemberRole.MEMBER);
+        assertThat(docBSession.getAttributes().get("role")).isEqualTo(MemberRole.MEMBER);
+    }
+}

--- a/src/test/java/com/aidea/aidea/domain/teamspace/service/MemberServiceTest.java
+++ b/src/test/java/com/aidea/aidea/domain/teamspace/service/MemberServiceTest.java
@@ -1,0 +1,253 @@
+package com.aidea.aidea.domain.teamspace.service;
+
+import com.aidea.aidea.domain.auth.entity.User;
+import com.aidea.aidea.domain.auth.repository.UserRepository;
+import com.aidea.aidea.domain.invitation.repository.InvitationRepository;
+import com.aidea.aidea.domain.teamspace.dto.MemberInfoResponse;
+import com.aidea.aidea.domain.teamspace.entity.MemberRole;
+import com.aidea.aidea.domain.teamspace.entity.TeamspaceMember;
+import com.aidea.aidea.domain.teamspace.repository.TeamspaceMemberRepository;
+import com.aidea.aidea.global.exception.CustomException;
+import com.aidea.aidea.global.exception.ErrorCode;
+import com.aidea.aidea.global.util.TeamspaceRoleValidator;
+import com.aidea.aidea.global.websocket.MemberRoleChangeListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private TeamspaceMemberRepository teamspaceMemberRepository;
+    @Mock
+    private InvitationRepository invitationRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private MemberRoleChangeListener teamspaceListener;
+    @Mock
+    private MemberRoleChangeListener documentListener;
+
+    private MemberService memberService;
+
+    private static final String TEAMSPACE_ID = "ts-1";
+    private static final Long OWNER_ID = 1L;
+    private static final Long TARGET_ID = 2L;
+
+    @BeforeEach
+    void setUp() {
+        TeamspaceRoleValidator roleValidator = new TeamspaceRoleValidator(teamspaceMemberRepository);
+        memberService = new MemberService(
+                teamspaceMemberRepository,
+                invitationRepository,
+                userRepository,
+                roleValidator,
+                List.of(teamspaceListener, documentListener)
+        );
+    }
+
+    private TeamspaceMember member(Long userId, MemberRole role) {
+        return TeamspaceMember.builder()
+                .id(userId)
+                .teamspaceId(TEAMSPACE_ID)
+                .userId(userId)
+                .role(role)
+                .build();
+    }
+
+    private User user(Long userId) {
+        return User.builder()
+                .id(userId)
+                .name("user" + userId)
+                .email("user" + userId + "@example.com")
+                .build();
+    }
+
+    @Test
+    void changeMemberRole_promotesViewerToMember() {
+        TeamspaceMember caller = member(OWNER_ID, MemberRole.OWNER);
+        TeamspaceMember target = member(TARGET_ID, MemberRole.VIEWER);
+
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, OWNER_ID)).thenReturn(Optional.of(caller));
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, TARGET_ID)).thenReturn(Optional.of(target));
+        when(userRepository.findById(TARGET_ID)).thenReturn(Optional.of(user(TARGET_ID)));
+
+        MemberInfoResponse response = memberService.changeMemberRole(TEAMSPACE_ID, TARGET_ID, MemberRole.MEMBER, OWNER_ID);
+
+        assertThat(response.getRole()).isEqualTo("MEMBER");
+        assertThat(target.getRole()).isEqualTo(MemberRole.MEMBER);
+        verify(teamspaceListener).onMemberRoleChanged(TEAMSPACE_ID, TARGET_ID, MemberRole.MEMBER);
+        verify(documentListener).onMemberRoleChanged(TEAMSPACE_ID, TARGET_ID, MemberRole.MEMBER);
+    }
+
+    @Test
+    void changeMemberRole_demotesMemberToViewer() {
+        TeamspaceMember caller = member(OWNER_ID, MemberRole.OWNER);
+        TeamspaceMember target = member(TARGET_ID, MemberRole.MEMBER);
+
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, OWNER_ID)).thenReturn(Optional.of(caller));
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, TARGET_ID)).thenReturn(Optional.of(target));
+        when(userRepository.findById(TARGET_ID)).thenReturn(Optional.of(user(TARGET_ID)));
+
+        MemberInfoResponse response = memberService.changeMemberRole(TEAMSPACE_ID, TARGET_ID, MemberRole.VIEWER, OWNER_ID);
+
+        assertThat(response.getRole()).isEqualTo("VIEWER");
+        assertThat(target.getRole()).isEqualTo(MemberRole.VIEWER);
+        verify(teamspaceListener).onMemberRoleChanged(TEAMSPACE_ID, TARGET_ID, MemberRole.VIEWER);
+    }
+
+    @Test
+    void changeMemberRole_promotesMemberToCoOwner() {
+        TeamspaceMember caller = member(OWNER_ID, MemberRole.OWNER);
+        TeamspaceMember target = member(TARGET_ID, MemberRole.MEMBER);
+
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, OWNER_ID)).thenReturn(Optional.of(caller));
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, TARGET_ID)).thenReturn(Optional.of(target));
+        when(userRepository.findById(TARGET_ID)).thenReturn(Optional.of(user(TARGET_ID)));
+
+        MemberInfoResponse response = memberService.changeMemberRole(TEAMSPACE_ID, TARGET_ID, MemberRole.OWNER, OWNER_ID);
+
+        assertThat(response.getRole()).isEqualTo("OWNER");
+        assertThat(target.getRole()).isEqualTo(MemberRole.OWNER);
+    }
+
+    @Test
+    void changeMemberRole_ownerCanDemoteCoOwner_whenMultipleOwnersExist() {
+        TeamspaceMember caller = member(OWNER_ID, MemberRole.OWNER);
+        TeamspaceMember target = member(TARGET_ID, MemberRole.OWNER);
+
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, OWNER_ID)).thenReturn(Optional.of(caller));
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, TARGET_ID)).thenReturn(Optional.of(target));
+        when(teamspaceMemberRepository.countByTeamspaceIdAndRole(TEAMSPACE_ID, MemberRole.OWNER)).thenReturn(2L);
+        when(userRepository.findById(TARGET_ID)).thenReturn(Optional.of(user(TARGET_ID)));
+
+        MemberInfoResponse response = memberService.changeMemberRole(TEAMSPACE_ID, TARGET_ID, MemberRole.MEMBER, OWNER_ID);
+
+        assertThat(response.getRole()).isEqualTo("MEMBER");
+        assertThat(target.getRole()).isEqualTo(MemberRole.MEMBER);
+    }
+
+    @Test
+    void changeMemberRole_lastOwnerCannotBeDemoted() {
+        TeamspaceMember caller = member(OWNER_ID, MemberRole.OWNER);
+        TeamspaceMember target = caller; // 본인이 마지막 OWNER
+
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, OWNER_ID)).thenReturn(Optional.of(caller));
+        when(teamspaceMemberRepository.countByTeamspaceIdAndRole(TEAMSPACE_ID, MemberRole.OWNER)).thenReturn(1L);
+
+        assertThatThrownBy(() -> memberService.changeMemberRole(TEAMSPACE_ID, OWNER_ID, MemberRole.MEMBER, OWNER_ID))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.TEAMSPACE_LAST_OWNER);
+
+        assertThat(target.getRole()).isEqualTo(MemberRole.OWNER);
+        verify(teamspaceListener, never()).onMemberRoleChanged(any(), any(), any());
+        verify(documentListener, never()).onMemberRoleChanged(any(), any(), any());
+    }
+
+    @Test
+    void changeMemberRole_sameRole_isIdempotentAndDoesNotNotify() {
+        TeamspaceMember caller = member(OWNER_ID, MemberRole.OWNER); // 본인이 마지막 OWNER, role 변경 없음
+
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, OWNER_ID)).thenReturn(Optional.of(caller));
+        when(userRepository.findById(OWNER_ID)).thenReturn(Optional.of(user(OWNER_ID)));
+
+        MemberInfoResponse response = memberService.changeMemberRole(TEAMSPACE_ID, OWNER_ID, MemberRole.OWNER, OWNER_ID);
+
+        assertThat(response.getRole()).isEqualTo("OWNER");
+        verify(teamspaceMemberRepository, never()).countByTeamspaceIdAndRole(any(), any());
+        verify(teamspaceListener, never()).onMemberRoleChanged(any(), any(), any());
+        verify(documentListener, never()).onMemberRoleChanged(any(), any(), any());
+    }
+
+    @Test
+    void changeMemberRole_callerNotOwner_throwsInsufficientPermission() {
+        TeamspaceMember caller = member(OWNER_ID, MemberRole.MEMBER);
+
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, OWNER_ID)).thenReturn(Optional.of(caller));
+
+        assertThatThrownBy(() -> memberService.changeMemberRole(TEAMSPACE_ID, TARGET_ID, MemberRole.MEMBER, OWNER_ID))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INSUFFICIENT_PERMISSION);
+
+        verify(teamspaceMemberRepository, never()).findByTeamspaceIdAndUserId(TEAMSPACE_ID, TARGET_ID);
+    }
+
+    @Test
+    void changeMemberRole_callerNotTeamspaceMember_throwsNotTeamspaceMember() {
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, OWNER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> memberService.changeMemberRole(TEAMSPACE_ID, TARGET_ID, MemberRole.MEMBER, OWNER_ID))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_TEAMSPACE_MEMBER);
+    }
+
+    @Test
+    void changeMemberRole_targetNotTeamspaceMember_throwsNotTeamspaceMember() {
+        TeamspaceMember caller = member(OWNER_ID, MemberRole.OWNER);
+
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, OWNER_ID)).thenReturn(Optional.of(caller));
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, TARGET_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> memberService.changeMemberRole(TEAMSPACE_ID, TARGET_ID, MemberRole.MEMBER, OWNER_ID))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_TEAMSPACE_MEMBER);
+    }
+
+    @Test
+    void removeMember_lastOwner_throwsTeamspaceLastOwner() {
+        TeamspaceMember caller = member(OWNER_ID, MemberRole.OWNER);
+
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, OWNER_ID)).thenReturn(Optional.of(caller));
+        when(teamspaceMemberRepository.countByTeamspaceIdAndRole(TEAMSPACE_ID, MemberRole.OWNER)).thenReturn(1L);
+
+        assertThatThrownBy(() -> memberService.removeMember(TEAMSPACE_ID, OWNER_ID, OWNER_ID))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.TEAMSPACE_LAST_OWNER);
+
+        verify(teamspaceMemberRepository, never()).delete(any());
+    }
+
+    @Test
+    void removeMember_ownerWithMultipleOwners_succeeds() {
+        TeamspaceMember caller = member(OWNER_ID, MemberRole.OWNER);
+        TeamspaceMember target = member(TARGET_ID, MemberRole.OWNER);
+
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, OWNER_ID)).thenReturn(Optional.of(caller));
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, TARGET_ID)).thenReturn(Optional.of(target));
+        when(teamspaceMemberRepository.countByTeamspaceIdAndRole(TEAMSPACE_ID, MemberRole.OWNER)).thenReturn(2L);
+
+        memberService.removeMember(TEAMSPACE_ID, TARGET_ID, OWNER_ID);
+
+        verify(teamspaceMemberRepository).delete(target);
+    }
+
+    @Test
+    void removeMember_callerNotOwner_throwsNotTeamspaceOwner() {
+        TeamspaceMember caller = member(OWNER_ID, MemberRole.MEMBER);
+
+        when(teamspaceMemberRepository.findByTeamspaceIdAndUserId(TEAMSPACE_ID, OWNER_ID)).thenReturn(Optional.of(caller));
+
+        assertThatThrownBy(() -> memberService.removeMember(TEAMSPACE_ID, TARGET_ID, OWNER_ID))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_TEAMSPACE_OWNER);
+    }
+}

--- a/src/test/java/com/aidea/aidea/domain/teamspace/websocket/TeamspaceWebSocketHandlerTest.java
+++ b/src/test/java/com/aidea/aidea/domain/teamspace/websocket/TeamspaceWebSocketHandlerTest.java
@@ -1,0 +1,114 @@
+package com.aidea.aidea.domain.teamspace.websocket;
+
+import com.aidea.aidea.domain.auth.repository.UserRepository;
+import com.aidea.aidea.domain.teamspace.entity.MemberRole;
+import com.aidea.aidea.domain.teamspace.repository.TeamSpaceRepository;
+import com.aidea.aidea.global.websocket.SocketErrorSender;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TeamspaceWebSocketHandlerTest {
+
+    @Mock
+    private TeamSpaceRepository teamSpaceRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private SocketErrorSender socketErrorSender;
+
+    private TeamspaceWebSocketHandler handler;
+
+    private static final String TEAMSPACE_ID = "ts-1";
+
+    @BeforeEach
+    void setUp() {
+        handler = new TeamspaceWebSocketHandler(teamSpaceRepository, userRepository, new ObjectMapper(), socketErrorSender);
+    }
+
+    private WebSocketSession sessionWith(String userId, MemberRole role) {
+        WebSocketSession session = org.mockito.Mockito.mock(WebSocketSession.class);
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("teamspaceId", TEAMSPACE_ID);
+        attributes.put("userId", userId);
+        attributes.put("role", role);
+        when(session.getAttributes()).thenReturn(attributes);
+        lenient().when(session.getId()).thenReturn("session-" + userId);
+        lenient().when(session.isOpen()).thenReturn(true);
+        return session;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void registerSession(WebSocketSession session) throws Exception {
+        Field field = TeamspaceWebSocketHandler.class.getDeclaredField("teamspaceSessions");
+        field.setAccessible(true);
+        ConcurrentHashMap<String, Set<WebSocketSession>> sessions =
+                (ConcurrentHashMap<String, Set<WebSocketSession>>) field.get(handler);
+        sessions.computeIfAbsent(TEAMSPACE_ID, k -> ConcurrentHashMap.newKeySet()).add(session);
+    }
+
+    @Test
+    void onMemberRoleChanged_updatesCachedRoleForTargetUserSessions() throws Exception {
+        WebSocketSession targetSession = sessionWith("2", MemberRole.VIEWER);
+        WebSocketSession otherSession = sessionWith("3", MemberRole.MEMBER);
+        registerSession(targetSession);
+        registerSession(otherSession);
+
+        handler.onMemberRoleChanged(TEAMSPACE_ID, 2L, MemberRole.MEMBER);
+
+        assertThat(targetSession.getAttributes().get("role")).isEqualTo(MemberRole.MEMBER);
+        assertThat(otherSession.getAttributes().get("role")).isEqualTo(MemberRole.MEMBER); // unaffected, already MEMBER
+    }
+
+    @Test
+    void onMemberRoleChanged_broadcastsRoleChangedEventToAllSessions() throws Exception {
+        WebSocketSession targetSession = sessionWith("2", MemberRole.VIEWER);
+        WebSocketSession otherSession = sessionWith("3", MemberRole.MEMBER);
+        registerSession(targetSession);
+        registerSession(otherSession);
+
+        handler.onMemberRoleChanged(TEAMSPACE_ID, 2L, MemberRole.MEMBER);
+
+        ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(targetSession).sendMessage(captor.capture());
+        verify(otherSession).sendMessage(captor.capture());
+
+        for (TextMessage message : captor.getAllValues()) {
+            String payload = message.getPayload();
+            assertThat(payload).contains("\"event\":\"member:role_changed\"");
+            assertThat(payload).contains("\"userId\":2");
+            assertThat(payload).contains("\"role\":\"MEMBER\"");
+        }
+    }
+
+    @Test
+    void onMemberRoleChanged_doesNotUpdateOtherUsersCachedRole() throws Exception {
+        WebSocketSession targetSession = sessionWith("2", MemberRole.VIEWER);
+        WebSocketSession otherSession = sessionWith("3", MemberRole.VIEWER);
+        registerSession(targetSession);
+        registerSession(otherSession);
+
+        handler.onMemberRoleChanged(TEAMSPACE_ID, 2L, MemberRole.MEMBER);
+
+        assertThat(targetSession.getAttributes().get("role")).isEqualTo(MemberRole.MEMBER);
+        assertThat(otherSession.getAttributes().get("role")).isEqualTo(MemberRole.VIEWER);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #94

<br>

## 📝 작업 내용

OWNER가 팀스페이스 멤버의 역할을 변경할 수 있는 API를 추가했습니다.

주요 변경 사항:
- PATCH /api/teamspaces/{teamspaceId}/members/{memberId}/role 엔드포인트 추가
- 변경 가능 역할: OWNER / MEMBER / VIEWER, OWNER만 역할 변경 가능 (권한 검증)
- 팀스페이스에 최소 1명의 OWNER 유지 강제: 마지막 OWNER를 다른 역할로 변경 시 오류 반환
- 역할 변경 시 WebSocket을 통해 팀스페이스 내 모든 접속 클라이언트에 이벤트 전파
- TeamspaceWebSocketHandler / DocumentWebSocketHandler에 캐시된 세션 권한 즉시 갱신: 역할 변경이 실시간으로 접근 제어에 반영
- MemberService 역할 변경 로직 및 최소 1인 OWNER 보장 로직 단위 테스트 추가
- TeamspaceWebSocketHandler / DocumentWebSocketHandler의 role 캐시 갱신 및 이벤트 브로드캐스트 동작 단위 테스트 추가

<br>


## 테스트 및 검증 내용

- OWNER가 다른 멤버의 역할을 VIEWER로 변경 후 즉시 문서 편집 권한 차단 확인
- 마지막 OWNER를 MEMBER로 변경 시 오류 응답(400) 반환 확인
- 역할 변경 후 WebSocket 이벤트 수신 및 클라이언트 권한 캐시 갱신 확인
- OWNER가 아닌 멤버가 역할 변경 시도 시 403 응답 확인

<br>

## 🤔 주요 고민과 해결 과정

**[역할 변경의 실시간 반영]**

역할 변경이 DB에만 반영되고 세션 캐시는 갱신되지 않으면, 변경 전 역할로 계속 동작하는 문제가 발생합니다.
WebSocket 핸들러가 보유한 세션별 권한 캐시를 역할 변경 이벤트 수신 시 즉시 갱신하도록 처리하여 실시간 일관성을 확보했습니다.

**[최소 1인 OWNER 보장]**

역할 변경 처리 전 해당 팀스페이스의 OWNER 수를 확인하고,
1명이면서 변경 대상이 OWNER인 경우 변경을 거부하도록 서비스 레이어에서 유효성 검증을 수행했습니다.
